### PR TITLE
fix: remove accidental bootstrap_dependencies call

### DIFF
--- a/lua/rocks/init.lua
+++ b/lua/rocks/init.lua
@@ -27,7 +27,6 @@ function rocks.setup(opts)
     config = vim.tbl_deep_extend("force", config, opts or {})
 
     setup.init()
-    setup.bootstrap_dependencies()
 end
 
 return rocks


### PR DESCRIPTION
I added this in #3 and forgot to remove it again.