### PR TITLE
build: neovim derivation with rocks.nvim for manual testing with nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1698038711,
-        "narHash": "sha256-TEFTWsN5dWaiVjIndSdoo7fxZIztgS8bLRZExEsAzjU=",
+        "lastModified": 1698125142,
+        "narHash": "sha256-cE3wXVQjE0J87vMnTkeWdHpFr/z/n8C+L5+G2EC9Kao=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "be68fa5b88c2b29a11a410d73431fbac89b2927b",
+        "rev": "cd25dcb358e5b4b34851c2ecd88b19f04eec12ba",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1697984014,
-        "narHash": "sha256-fMlw0rw3sO5GsjQVowSo79fSnZQAMT+w1gAkuKuNxw0=",
+        "lastModified": 1698090486,
+        "narHash": "sha256-MEtswTlBJ4DTXmAflsyN9B3saGnBoMM/YDsC+roAEGA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "bc850ba2a090a9a4733a82a7555a5a70264ce1ac",
+        "rev": "25cfe3fd432d77689446fe5a0bb972479298387c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
         packages = rec {
           default = rocks-nvim;
           inherit (pkgs.vimPlugins) rocks-nvim;
+          inherit (pkgs) neovim-with-rocks;
         };
 
         # TODO: add integration-stable when ready

--- a/lua/rocks/init.lua
+++ b/lua/rocks/init.lua
@@ -27,7 +27,6 @@ function rocks.setup(opts)
     config = vim.tbl_deep_extend("force", config, opts or {})
 
     setup.init()
-    setup.bootstrap_dependencies()
 end
 
 return rocks

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -1,9 +1,68 @@
 {
   name,
   self,
-}: final: prev: {
-  vimPlugins.rocks-nvim = final.pkgs.vimUtils.buildVimPlugin {
-    inherit name;
+}: final: prev: let
+  lib = final.lib;
+  rocks-nvim-luaPackage-override = luaself: luaprev: {
+    rocks-nvim = luaself.callPackage ({
+      luaOlder,
+      buildLuarocksPackage,
+      lua,
+      toml,
+      toml-edit,
+    }:
+      buildLuarocksPackage {
+        pname = name;
+        version = "scm-1";
+        knownRockspec = "${self}/rocks.nvim-scm-1.rockspec";
+        src = self;
+        disabled = luaOlder "5.1";
+        propagatedBuildInputs = [toml toml-edit];
+      }) {};
+  };
+  lua5_1 = prev.lua5_1.override {
+    packageOverrides = rocks-nvim-luaPackage-override;
+  };
+  lua51Packages = final.lua5_1.pkgs;
+in {
+  inherit lua5_1 lua51Packages;
+
+  vimPlugins.rocks-nvim = final.neovimUtils.buildNeovimPlugin {
+    pname = name;
+    version = "dev";
     src = self;
   };
+
+  neovim-with-rocks = let
+    neovimConfig = final.neovimUtils.makeNeovimConfig {
+      withPython3 = true;
+      viAlias = true;
+      vimAlias = true;
+      plugins = with final.vimPlugins; [
+        rocks-nvim
+      ];
+    };
+    runtimeDeps = with final; [
+      lua5_1
+      luarocks
+    ];
+  in
+    final.wrapNeovimUnstable final.neovim-nightly (neovimConfig
+      // {
+        wrapperArgs =
+          lib.escapeShellArgs neovimConfig.wrapperArgs
+          + " "
+          + ''--set NVIM_APPNAME "nvimrocks"''
+          + " "
+          + ''--suffix LUA_CPATH ";" "${
+              lib.concatMapStringsSep ";" lua51Packages.getLuaCPath
+              (with lua51Packages; [
+                toml
+                toml-edit
+              ])
+            }"''
+          + " "
+          + ''--prefix PATH : "${lib.makeBinPath runtimeDeps}"'';
+        wrapRc = false;
+      });
 }

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -8,8 +8,7 @@
         neovim = nvim;
         luaPackages = ps:
           with ps; [
-            # FIXME: https://github.com/NixOS/nixpkgs/pull/261116
-            # toml-edit
+            toml-edit
             toml
             plenary-nvim
           ];

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -6,10 +6,16 @@ rockspec_format = "3.0"
 package = "rocks.nvim"
 version = _MODREV .. _SPECREV
 
+dependencies = {
+    "lua >= 5.1",
+    "toml-edit",
+    "toml",
+}
+
 test_dependencies = {
     "lua >= 5.1",
-    -- "toml-edit",
-    -- "toml",
+    "toml-edit",
+    "toml",
 }
 
 source = {


### PR DESCRIPTION
Currently, you have to call `:lua require('rocks').setup()` for the plugin to initialize.

### FIXMEs:

- [x] We need to get rid of the `setup` function (separate PR)
- [x] I had to add `toml` and `toml-edit` to the `LUA_CPATH` via `wrapperArgs`(@teto I thought `buildNeovimPlugin` adds the dependencies?).
- [ ] Haven't been able to test `:Rocks install` yet.