### PR TITLE
docs: fix copyright notice in the source code files header

### DIFF
--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -14,7 +14,7 @@
 ---@brief ]]
 ---
 
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/config/check.lua
+++ b/lua/rocks/config/check.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.config.check rocks.nvim config validation
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.config.internal rocks.nvim internal configuration
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/constants.lua
+++ b/lua/rocks/constants.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.constants
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/fs.lua
+++ b/lua/rocks/fs.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.fs
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/health.lua
+++ b/lua/rocks/health.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.health rocks.nvim health checks
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/init.lua
+++ b/lua/rocks/init.lua
@@ -8,7 +8,7 @@
 ---
 ---@brief ]]
 
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/internal-types.lua
+++ b/lua/rocks/internal-types.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.internal-types
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/luarocks.lua
+++ b/lua/rocks/luarocks.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.luarocks
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.operations
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/search.lua
+++ b/lua/rocks/search.lua
@@ -7,7 +7,7 @@
 ---@brief ]]
 ---
 ---
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.state
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3

--- a/lua/rocks/types.lua
+++ b/lua/rocks/types.lua
@@ -1,6 +1,6 @@
 ---@mod rocks.types
 --
--- Copyright (C) 2023 NTBBloodbath
+-- Copyright (C) 2023 Neorocks Org.
 --
 -- Version:    0.1.0
 -- License:    GPLv3


### PR DESCRIPTION
I updated the copyright notice of the source code headers to use the name of the neorocks organization, since this is no longer a private project under my profile