### PR TITLE
feat: add nui.nvim dependency to the manifest

### DIFF
--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -10,6 +10,7 @@
       lua,
       toml,
       toml-edit,
+      nui-nvim,
     }:
       buildLuarocksPackage {
         pname = name;
@@ -17,7 +18,7 @@
         knownRockspec = "${self}/rocks.nvim-scm-1.rockspec";
         src = self;
         disabled = luaOlder "5.1";
-        propagatedBuildInputs = [toml toml-edit];
+        propagatedBuildInputs = [toml toml-edit nui-nvim];
       }) {};
   };
   lua5_1 = prev.lua5_1.override {

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -11,6 +11,7 @@
             toml-edit
             toml
             plenary-nvim
+            nui-nvim
           ];
 
         extraPackages = [

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -10,12 +10,14 @@ dependencies = {
     "lua >= 5.1",
     "toml-edit",
     "toml",
+    "nui.nvim",
 }
 
 test_dependencies = {
     "lua >= 5.1",
     "toml-edit",
     "toml",
+    "nui.nvim",
 }
 
 source = {


### PR DESCRIPTION
We are using [nui.nvim](https://luarocks.org/modules/MunifTanjim/nui.nvim) to create the user interfaces, but the dependency is not declared in the luarocks manifests or the Nix flake (only in the internal bootstrapping process that is going to be deprecated later). This PR seeks to solve this inconsistency.

- [x] Add nui to rockspec
- [x] Add nui to Nix flake