### PR TITLE
ci: add static type checking for neovim-nightly

### DIFF
--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -28,11 +28,15 @@
 in {
   inherit lua5_1 lua51Packages;
 
-  vimPlugins.rocks-nvim = final.neovimUtils.buildNeovimPlugin {
-    pname = name;
-    version = "dev";
-    src = self;
-  };
+  vimPlugins =
+    prev.vimPlugins
+    // {
+      rocks-nvim = final.neovimUtils.buildNeovimPlugin {
+        pname = name;
+        version = "dev";
+        src = self;
+      };
+    };
 
   neovim-with-rocks = let
     neovimConfig = final.neovimUtils.makeNeovimConfig {


### PR DESCRIPTION
This adds static type checking for neovim-nightly to our CI.

Note that I didn't add it as a pre-commit-hook to the Nix shell, because it can be quite slow.