### PR TITLE
hotfix: do not hardcode luarocks binary in `luarocks.cli` function

### DIFF
--- a/lua/rocks/config/check.lua
+++ b/lua/rocks/config/check.lua
@@ -32,8 +32,9 @@ end
 ---@return string|nil error_message
 function check.validate(cfg)
     local ok, err = validate({
-        config_path = { cfg.config_path, "string" },
         rocks_path = { cfg.rocks_path, "string" },
+        config_path = { cfg.config_path, "string" },
+        luarocks_binary = { cfg.luarocks_binary, "string" },
     })
     if not ok then
         return false, err

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -16,6 +16,7 @@ local config = {}
 ---@class RocksOpts
 ---@field rocks_path? string Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
 ---@field config_path? string Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
+---@field luarocks_binary? string Luarocks binary path. Defaults to `luarocks`.
 
 ---@type RocksOpts | fun():RocksOpts
 vim.g.rocks_nvim = vim.g.rocks_nvim

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -26,6 +26,8 @@ local default_config = {
     rocks_path = vim.fs.joinpath(vim.fn.stdpath("data"), "rocks"),
     ---@diagnostic disable-next-line: param-type-mismatch
     config_path = vim.fs.joinpath(vim.fn.stdpath("config"), "rocks.toml"),
+    ---@diagnostic disable-next-line: param-type-mismatch
+    luarocks_binary = "luarocks",
 }
 
 ---@type RocksOpts

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -18,6 +18,7 @@
 ---@class (exact) RocksConfig
 ---@field rocks_path string Local path in your filesystem to install rocks
 ---@field config_path string Rocks declaration file path
+---@field luarocks_binary string Luarocks binary path
 
 --- rocks.nvim default configuration
 ---@type RocksConfig
@@ -26,7 +27,6 @@ local default_config = {
     rocks_path = vim.fs.joinpath(vim.fn.stdpath("data"), "rocks"),
     ---@diagnostic disable-next-line: param-type-mismatch
     config_path = vim.fs.joinpath(vim.fn.stdpath("config"), "rocks.toml"),
-    ---@diagnostic disable-next-line: param-type-mismatch
     luarocks_binary = "luarocks",
 }
 

--- a/lua/rocks/luarocks.lua
+++ b/lua/rocks/luarocks.lua
@@ -28,7 +28,7 @@ local config = require("rocks.config.internal")
 ---@see vim.system
 luarocks.cli = function(args, on_exit, opts)
     local luarocks_cmd = vim.list_extend({
-        "luarocks",
+        config.luarocks_binary,
         "--lua-version=" .. constants.LUA_VERSION,
         "--tree=" .. config.rocks_path,
         "--server='https://nvim-neorocks.github.io/rocks-binaries/'",


### PR DESCRIPTION
Also added the `luarocks_binary` configuration option to the `config` module, which is added by the installer and we had forgotten to add it there :p

This fixes operations when luarocks was compiled by `rocks.nvim` as otherwise any `:Rocks` command will fail with a `ENOENT: no such file or directory` error message from the Neovim API when trying to execute `luarocks` commands.