### PR TITLE
feat: allow users to install development rocks (`scm-1`)

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -41,8 +41,9 @@ rocks.nvim configuration                                          *rocks.config*
 RocksOpts                                                            *RocksOpts*
 
     Fields: ~
-        {rocks_path?}   (string)  Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
-        {config_path?}  (string)  Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
+        {rocks_path?}       (string)  Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
+        {config_path?}      (string)  Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
+        {luarocks_binary?}  (string)  Luarocks binary path. Defaults to `luarocks`.
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
The following ways are valid:

- `nvim-treesitter = "scm-1"` in your `rocks.toml`
- `:Rocks install nvim-treesitter dev`, operations will get `dev` version and convert it to `--dev` flag when installing the rock