### PR TITLE
feat: `:Rocks prune` command to uninstall rocks and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ The `:Rocks sync` command synchronizes the installed rocks with the `rocks.toml`
 
 ### Uninstalling rocks
 
-To uninstall a rock, edit the `rocks.toml` and run `:Rocks sync`.
+To uninstall a rock and any of its dependencies,
+that are no longer needed, run the `:Rocks prune [rock]` command.
+
+> [!NOTE]
+>
+> - The command provides completions for rocks that can safely
+>   be pruned without breaking dependencies.
 
 ## :book: License
 

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
               editorconfig-checker
             ]
             ++ (with pkgs; [
+              lua5_1
               luarocks
             ]);
         };

--- a/lua/nio/control.lua
+++ b/lua/nio/control.lua
@@ -12,8 +12,7 @@ nio.control = {}
 --- The event can be set from a non-async context.
 ---@class nio.control.Event
 ---@field set fun(max_woken?: integer): nil Set the event and signal to all (or limited number of) listeners that the event has occurred. If max_woken is provided and there are more listeners then the event is cleared immediately
----@field wait async fun(): nil Wait for the event to occur, returning immediately if
---- already set
+---@field wait async fun(): nil Wait for the event to occur, returning immediately if already set
 ---@field clear fun(): nil Clear the event
 ---@field is_set fun(): boolean Returns true if the event is set
 

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -41,6 +41,14 @@ local rocks_command_tbl = {
         local package, version = args[1], args[2]
         require("rocks.operations").add(package, version)
     end,
+    prune = function(args)
+        if #args == 0 then
+            vim.notify("Rocks prune: Called without required package argument.", vim.log.levels.ERROR)
+            return
+        end
+        local package = args[1]
+        require("rocks.operations").prune(package)
+    end,
 }
 
 local function rocks(opts)
@@ -75,6 +83,12 @@ function commands.create_commands()
             end
             local name_query = cmdline:match("^Rocks install%s(.*)$")
             local rocks_list = search.complete_names(name_query)
+            if #rocks_list > 0 then
+                return rocks_list
+            end
+            local state = require("rocks.state")
+            name_query = cmdline:match("^Rocks prune%s(.*)$")
+            rocks_list = state.complete_removable_rocks(name_query)
             if #rocks_list > 0 then
                 return rocks_list
             end

--- a/lua/rocks/internal-types.lua
+++ b/lua/rocks/internal-types.lua
@@ -19,6 +19,9 @@
 ---@field public name string
 ---@field public version string
 
+---@class OutdatedRock: Rock
+---@field public target_version string
+
 ---@class (exact) RockDependency
 ---@field public name string
 ---@field public version? string


### PR DESCRIPTION
- [x] Tested manually using the Nix derivation.

Test steps:

1, `:Rocks install plenary.nvim` (depends on `luassert`, which depends on `say`, ...) + `haskell-tools.nvim` + `neorg`
2. `:Rocks prune <tab>` -> Completion works as expected, without suggesting dependencies.

![scrot](https://github.com/nvim-neorocks/rocks.nvim/assets/12857160/e592d781-1094-4270-a6b2-0af96aeb8489)

3. `:Rocks prune plenary.nvim` -> Uninstalls `plenary.nvim` and its dependencies.
4. `:Rocks prune <tab>` -> Shows completions for remaining rocks (`haskell-tools.nvim`, `neorg`).