### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Any change to files in the root directory, any later match takes precedence.
+* @NTBBloodbath @vhyrro @mrcjkb
+
+# Documentation
+*.md @NTBBloodbath @vhyrro @mrcjkb
+doc/ @NTBBloodbath @vhyrro @mrcjkb
+
+# Plugin files
+lua/ @NTBBloodbath @vhyrro @mrcjkb
+spec/ @NTBBloodbath @vhyrro @mrcjkb
+plugin/ @NTBBloodbath @vhyrro @mrcjkb
+
+# Nix
+nix/ @mrcjkb @teto
+flake.* @mrcjkb @teto


### PR DESCRIPTION
See [About code owners - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

I've added @teto only in the files referring to Nix for review automatically since he doesn't contribute as actively to the rest of the files. Is it okay like this or should I add him to the rest as well?