### PR TITLE
feat(commands): fuzzy completions for `:Rocks install [rock]`

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -34,6 +34,7 @@ jobs:
             toml-edit
             toml
             nui.nvim
+            fzy
           labels: |
             neovim
           summary: "Neovim plugin management inspired by `Cargo`."

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Arguments:
 
 > [!NOTE]
 >
-> - The command provides completions for rocks and versions on luarocks.org.
+> - The command provides fuzzy completions for rocks and versions on luarocks.org.
 > - Installs the latest version if `version` is omitted.
 > - This plugin keeps track of installed plugins in a `rocks.toml` file,
 >   which you can commit to version control.
@@ -110,7 +110,7 @@ that are no longer needed, run the `:Rocks prune [rock]` command.
 
 > [!NOTE]
 >
-> - The command provides completions for rocks that can safely
+> - The command provides fuzzy completions for rocks that can safely
 >   be pruned without breaking dependencies.
 
 ### Editing `rocks.toml`

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1698125142,
-        "narHash": "sha256-cE3wXVQjE0J87vMnTkeWdHpFr/z/n8C+L5+G2EC9Kao=",
+        "lastModified": 1701674652,
+        "narHash": "sha256-EeED7IS2EYGJTLgoDKzbBPwUMtopSmwX46roU0BydwM=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "cd25dcb358e5b4b34851c2ecd88b19f04eec12ba",
+        "rev": "f4118393f0f70a35eb4d5f9e9d2b8c440a58143f",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1698090486,
-        "narHash": "sha256-MEtswTlBJ4DTXmAflsyN9B3saGnBoMM/YDsC+roAEGA=",
+        "lastModified": 1701643367,
+        "narHash": "sha256-1R/BkHjrmqxQC0rE2kQu8b2L3G1Ap6GfdiiH6LUVeek=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "25cfe3fd432d77689446fe5a0bb972479298387c",
+        "rev": "5651c1ff27a1eb59d120637ba5cbd90f08a3f1d2",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {
@@ -246,11 +246,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
         "type": "github"
       },
       "original": {
@@ -295,16 +295,15 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1701730478,
+        "narHash": "sha256-ozWxAwmq05Ksr0clQEsr/fRbVm2cqiMLX1/ZHqM2tc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "e62e1b3ad321a1f923f97f2b242f39729f1982e4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -321,11 +320,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1697746376,
-        "narHash": "sha256-gu77VkgdfaHgNCVufeb6WP9oqFLjwK4jHcoPZmBVF3E=",
+        "lastModified": 1700922917,
+        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cc349bfd082da8782b989cad2158c9ad5bd70fd",
+        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
         "type": "github"
       },
       "original": {
@@ -345,11 +344,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1697746376,
-        "narHash": "sha256-gu77VkgdfaHgNCVufeb6WP9oqFLjwK4jHcoPZmBVF3E=",
+        "lastModified": 1700922917,
+        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cc349bfd082da8782b989cad2158c9ad5bd70fd",
+        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs";
 
     neorocks.url = "github:nvim-neorocks/neorocks";
 
@@ -79,6 +79,7 @@
                           "${toml-edit}/lib/lua/5.1/"
                           "${toml}/lib/lua/5.1/"
                           "${nui-nvim}/share/lua/5.1"
+                          "${fzy}/share/lua/5.1"
                         ])
                         ++ [
                           "\${3rd}/busted/library"

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -75,7 +75,9 @@ function commands.create_commands()
         nargs = "+",
         desc = "Interacts with currently installed rocks",
         complete = function(arg_lead, cmdline, _)
+            local fzy = require("rocks.fzy")
             local search = require("rocks.search")
+
             local rocks_commands = vim.tbl_keys(rocks_command_tbl)
 
             local name, version_query = cmdline:match("^Rocks install%s([^%s]+)%s(.+)$")
@@ -99,11 +101,7 @@ function commands.create_commands()
                 return rocks_list
             end
             if cmdline:match("^Rocks%s+%w*$") then
-                return vim.iter(rocks_commands)
-                    :filter(function(command)
-                        return command:find(arg_lead) ~= nil
-                    end)
-                    :totable()
+                return fzy.fuzzy_filter_sort(arg_lead, rocks_commands)
             end
         end,
     })

--- a/lua/rocks/fzy.lua
+++ b/lua/rocks/fzy.lua
@@ -1,0 +1,51 @@
+---@mod rocks.fzy fzy helpers
+---
+---@brief [[
+---
+--- Provides an adapter to fzy
+---
+---@brief ]]
+---
+---
+-- Copyright (C) 2023 Neorocks Org.
+--
+-- Version:    0.1.0
+-- License:    GPLv3
+-- Created:    05 Dec 2023
+-- Updated:    05 Dec 2023
+-- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
+-- Maintainer: NTBBloodbath <bloodbathalchemist@protonmail.com>
+
+local fzy_adapter = {}
+
+local fzy = require("fzy")
+
+---@alias index integer
+---@alias fzy_position integer
+---@alias score number
+---@alias FzyResult { [1]: index, [2]: fzy_position[], [3]: score }
+---@alias FzyResults FzyResult[]
+
+---Fuzzy-filter a list of items.
+---@param query string The query to fuzzy-match.
+---@param items string[] The items to search.
+---@return string[] Matching items, sorted by score (higher score first).
+function fzy_adapter.fuzzy_filter_sort(query, items)
+    local fzy_results = fzy.filter(query, items) or {}
+    table.sort(fzy_results, function(a, b)
+        ---@cast a FzyResult
+        ---@cast b FzyResult
+        local score_a = a[3]
+        local score_b = b[3]
+        return score_a > score_b
+    end)
+    return vim.iter(fzy_results)
+        :map(function(fzy_result)
+            ---@cast fzy_result FzyResult
+            local idx = fzy_result[1]
+            return items[idx]
+        end)
+        :totable()
+end
+
+return fzy_adapter

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -22,6 +22,7 @@ local state = {}
 local _removable_rock_cache = nil
 
 local luarocks = require("rocks.luarocks")
+local fzy = require("rocks.fzy")
 local nio = require("nio")
 
 ---@async
@@ -165,11 +166,7 @@ state.complete_removable_rocks = function(query)
     if not query then
         return {}
     end
-    return vim.iter(_removable_rock_cache)
-        :filter(function(rock_name)
-            return vim.startswith(rock_name, query)
-        end)
-        :totable()
+    return fzy.fuzzy_filter_sort(query, _removable_rock_cache)
 end
 
 state.invalidate_cache = function()

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -11,6 +11,7 @@
       toml,
       toml-edit,
       nui-nvim,
+      fzy,
     }:
       buildLuarocksPackage {
         pname = name;
@@ -18,7 +19,12 @@
         knownRockspec = "${self}/rocks.nvim-scm-1.rockspec";
         src = self;
         disabled = luaOlder "5.1";
-        propagatedBuildInputs = [toml toml-edit nui-nvim];
+        propagatedBuildInputs = [
+          toml
+          toml-edit
+          nui-nvim
+          fzy
+        ];
       }) {};
   };
   lua5_1 = prev.lua5_1.override {
@@ -59,11 +65,23 @@ in {
           + " "
           + ''--set NVIM_APPNAME "nvimrocks"''
           + " "
+          # XXX: Luarocks packages need to be added manaully,
+          # using LUA_PATH and LUA_CPATH.
+          # It looks like buildNeovimPlugin is broken?
           + ''--suffix LUA_CPATH ";" "${
               lib.concatMapStringsSep ";" lua51Packages.getLuaCPath
               (with lua51Packages; [
                 toml
                 toml-edit
+                nui-nvim
+                fzy
+              ])
+            }"''
+          + " "
+          + ''--suffix LUA_PATH ";" "${
+              lib.concatMapStringsSep ";" lua51Packages.getLuaPath
+              (with lua51Packages; [
+                fzy
               ])
             }"''
           + " "

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -12,6 +12,7 @@
             toml
             plenary-nvim
             nui-nvim
+            fzy
           ];
 
         extraPackages = [

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -11,6 +11,7 @@ dependencies = {
     "toml-edit",
     "toml",
     "nui.nvim",
+    "fzy",
 }
 
 test_dependencies = {
@@ -18,6 +19,7 @@ test_dependencies = {
     "toml-edit",
     "toml",
     "nui.nvim",
+    "fzy",
 }
 
 source = {
@@ -27,7 +29,7 @@ source = {
 build = {
     type = "builtin",
     copy_directories = {
-        -- 'doc',
+        'doc',
         "plugin",
     },
 }


### PR DESCRIPTION
Uses `fzy` to implement fuzzy completions for rocks in the `:Rocks install` command.

Manual test:

```console
nix run .#neovim-with-rocks
```
```vim
:Rocks ill<TAB>
```

Completes to `:Rocks install`.

```vim
:Rocks install norg<TAB>
```

Shows `neorg` as the first completion result.

Install `neorg` if not installed.

```vim
:Rocks prune norg<TAB>
```

Shows `neorg` as the first completion result.

