### PR TITLE
fix(internal): use `vim.empty_dict` for better vimscript interop

### DIFF
--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -141,8 +141,8 @@ operations.sync = function(user_rocks)
         ---@diagnostic disable-next-line: invisible
         local key_list = nio.fn.keys(vim.tbl_deep_extend("force", installed_rocks, user_rocks))
 
-        ---@type (fun():any)[]
-        local actions = {}
+        local actions = vim.empty_dict()
+        ---@cast actions (fun():any)[]
 
         local split = Split({
             relative = "editor",
@@ -152,11 +152,11 @@ operations.sync = function(user_rocks)
 
         local line_nr = 1
 
-        ---@type {[string]: RockDependency}
-        local dependencies = {}
+        local dependencies = vim.empty_dict()
+        ---@cast dependencies {[string]: RockDependency}
 
-        ---@type string[]
-        local to_remove_keys = {}
+        local to_remove_keys = vim.empty_dict()
+        ---@cast to_remove_keys string[]
 
         for _, key in ipairs(key_list) do
             local linenr_copy = line_nr
@@ -273,7 +273,8 @@ operations.update = function()
         local NuiText = require("nui.text")
 
         local outdated_rocks = state.outdated_rocks()
-        local actions = {}
+        local actions = vim.empty_dict()
+        ---@cast actions table
 
         nio.scheduler()
 
@@ -336,7 +337,7 @@ operations.add = function(rock_name, version)
             -- and populate the table upfront then none of the values will be registered by `toml-edit`.
             -- This should be fixed ASAP.
             if not user_rocks.plugins then
-                user_rocks.plugins = {}
+                user_rocks.plugins = vim.empty_dict()
             end
 
             -- Set installed version as `scm-1` if development version has been installed

--- a/lua/rocks/search.lua
+++ b/lua/rocks/search.lua
@@ -29,7 +29,8 @@ local populate_cache = nio.create(function()
     if _cache then
         return
     end
-    _cache = {}
+    _cache = vim.empty_dict()
+    ---@cast _cache Rock[]
     local future = nio.control.future()
     luarocks.cli({ "search", "--porcelain", "--all" }, function(obj)
         ---@cast obj vim.SystemCompleted

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -27,8 +27,8 @@ local nio = require("nio")
 ---@async
 ---@type fun(): {[string]: Rock}
 state.installed_rocks = nio.create(function()
-    ---@type {[string]: Rock}
-    local rocks = {}
+    local rocks = vim.empty_dict()
+    ---@cast rocks {[string]: Rock}
 
     local future = nio.control.future()
 
@@ -55,8 +55,8 @@ end)
 ---@async
 ---@type fun(): {[string]: OutdatedRock}
 state.outdated_rocks = nio.create(function()
-    ---@type {[string]: Rock}
-    local rocks = {}
+    local rocks = vim.empty_dict()
+    ---@cast rocks {[string]: Rock}
 
     local future = nio.control.future()
 
@@ -87,8 +87,8 @@ end)
 state.rock_dependencies = nio.create(function(rock)
     ---@cast rock Rock|string
 
-    ---@type {[string]: RockDependency}
-    local dependencies = {}
+    local dependencies = vim.empty_dict()
+    ---@cast dependencies {[string]: RockDependency}
 
     local future = nio.control.future()
 
@@ -130,8 +130,8 @@ end)
 state.query_removable_rocks = nio.create(function()
     local installed_rocks = state.installed_rocks()
     --- Unfortunately, luarocks can't list dependencies via its CLI.
-    ---@type string[]
-    local dependent_rocks = {}
+    local dependent_rocks = vim.empty_dict()
+    ---@cast dependent_rocks string[]
     for _, rock in pairs(installed_rocks) do
         for _, dep in pairs(state.rock_dependencies(rock)) do
             dependent_rocks[#dependent_rocks + 1] = dep.name


### PR DESCRIPTION
Should prevent errors like this one:

![image](https://github.com/nvim-neorocks/rocks.nvim/assets/12857160/be8292e6-4812-4ccd-91a8-45fc6e2413fe)


Manual test steps:

- Tested that `:Rocks install` and `:Rocks prune` still work (using the nix derivation).