### PR TITLE
chore(nix): add init.lua to load rocks to nvimrocks derivation

### DIFF
--- a/nix/init.lua
+++ b/nix/init.lua
@@ -1,0 +1,23 @@
+-- Copied from installer.lua
+-- TODO: Maybe it's a good idea to have a single source of truth for this?
+
+local rocks_config = {
+    rocks_path = vim.fn.stdpath("data") .. "/rocks",
+    luarocks_binary = "luarocks",
+}
+
+vim.g.rocks_nvim = rocks_config
+
+local luarocks_path = {
+    vim.fs.joinpath(rocks_config.rocks_path, "share", "lua", "5.1", "?.lua"),
+    vim.fs.joinpath(rocks_config.rocks_path, "share", "lua", "5.1", "?", "init.lua"),
+}
+package.path = package.path .. ";" .. table.concat(luarocks_path, ";")
+
+local luarocks_cpath = {
+    vim.fs.joinpath(rocks_config.rocks_path, "lib", "lua", "5.1", "?.so"),
+    vim.fs.joinpath(rocks_config.rocks_path, "lib64", "lua", "5.1", "?.so"),
+}
+package.cpath = package.cpath .. ";" .. table.concat(luarocks_cpath, ";")
+
+vim.opt.runtimepath:append(vim.fs.joinpath(rocks_config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", "*"))

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -51,11 +51,14 @@ in {
       lua5_1
       luarocks
     ];
+    customRC = builtins.readFile ./init.lua;
   in
     final.wrapNeovimUnstable final.neovim-nightly (neovimConfig
       // {
         wrapperArgs =
           lib.escapeShellArgs neovimConfig.wrapperArgs
+          + " "
+          + ''--add-flags -u --add-flags "${final.writeText "init.lua" customRC}"''
           + " "
           + ''--set NVIM_APPNAME "nvimrocks"''
           + " "
@@ -68,6 +71,5 @@ in {
             }"''
           + " "
           + ''--prefix PATH : "${lib.makeBinPath runtimeDeps}"'';
-        wrapRc = false;
       });
 }


### PR DESCRIPTION
The test derivation only lets us install/prune plugins.

This adds an `init.lua` that lets us use the installed plugins with the test dervation.

Test steps:

```console
nix run .#nvim-with-rocks
```

```vim
:Rocks install neorg
" wait for install to finish
:q
```

```console
nix run .#nvim-with-rocks
```

```vim
:lua =require('neorg')
```

-> prints the neorg module table