### PR TITLE
feat(ui): use fidget.nvim for progress reports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.{nix,md}]
+[*.{nix,md,json}]
 indent_size = 2
 
 [Makefile]

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -33,7 +33,7 @@ jobs:
           dependencies: |
             toml-edit
             toml
-            nui.nvim
+            fidget.nvim >= 1.1.0
             fzy
           labels: |
             neovim

--- a/.neoconf.json
+++ b/.neoconf.json
@@ -1,0 +1,18 @@
+{
+  "neodev": {
+    "library": {
+      "enabled": true,
+      "plugins": [
+        "fidget.nvim",
+        "nui.nvim",
+      ]
+    }
+  },
+  "neoconf": {
+    "plugins": {
+      "lua_ls": {
+        "enabled": true
+      }
+    }
+  },
+}

--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1701674652,
-        "narHash": "sha256-EeED7IS2EYGJTLgoDKzbBPwUMtopSmwX46roU0BydwM=",
+        "lastModified": 1702158815,
+        "narHash": "sha256-y3O/NewehDT8r+STm+CgL6G01i0FDxHjJ9L0hmMTYbc=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "f4118393f0f70a35eb4d5f9e9d2b8c440a58143f",
+        "rev": "10fa1daaa8ca6fb85333f5810359464f4ad2cde3",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1701643367,
-        "narHash": "sha256-1R/BkHjrmqxQC0rE2kQu8b2L3G1Ap6GfdiiH6LUVeek=",
+        "lastModified": 1702092971,
+        "narHash": "sha256-wPsZF7YQBqr/joUK5uJSPc8BY9wJepuLy/oSmNgJK4U=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5651c1ff27a1eb59d120637ba5cbd90f08a3f1d2",
+        "rev": "2ebd328a798778825be61015acd975d8a929dfec",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701626906,
-        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
+        "lastModified": 1701693815,
+        "narHash": "sha256-7BkrXykVWfkn6+c1EhFA3ko4MLi3gVG0p9G96PNnKTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
+        "rev": "09ec6a0881e1a36c29d67497693a67a16f4da573",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1701730478,
-        "narHash": "sha256-ozWxAwmq05Ksr0clQEsr/fRbVm2cqiMLX1/ZHqM2tc4=",
+        "lastModified": 1702157165,
+        "narHash": "sha256-cUQ1COr2+/74vyEdU2DIIs9+VkfReMtJwimc2/rZNDI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e62e1b3ad321a1f923f97f2b242f39729f1982e4",
+        "rev": "82cdeab2aa574c255c8d8c96d796453e02c8af60",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
                         ++ (with pkgs.lua51Packages; [
                           "${toml-edit}/lib/lua/5.1/"
                           "${toml}/lib/lua/5.1/"
-                          "${nui-nvim}/share/lua/5.1"
+                          "${fidget-nvim}/share/lua/5.1"
                           "${fzy}/share/lua/5.1"
                         ])
                         ++ [

--- a/lua/rocks/constants.lua
+++ b/lua/rocks/constants.lua
@@ -5,7 +5,7 @@
 -- Version:    0.1.0
 -- License:    GPLv3
 -- Created:    05 Jul 2023
--- Updated:    27 Aug 2023
+-- Updated:    09 Dec 2023
 -- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
 -- Maintainer: NTBBloodbath <bloodbathalchemist@protonmail.com>
 --
@@ -28,7 +28,8 @@ constants.ROCKS_VERSION = "2.1.0"
 
 --- Default configuration file contents
 ---@type string
-constants.DEFAULT_CONFIG = string.format([[
+constants.DEFAULT_CONFIG = string.format(
+    [[
 # This is your rocks.nvim plugins declaration file.
 # Here is a small yet pretty detailed example on how to use it:
 #
@@ -50,7 +51,12 @@ constants.DEFAULT_CONFIG = string.format([[
 # If the plugin name contains a dot then you must add quotes to the key name!
 [plugins]
 "rocks.nvim" = "%s-1" # rocks.nvim can also manage itself :D
-]], constants.ROCKS_VERSION)
+]],
+    constants.ROCKS_VERSION
+)
+
+---@type string
+constants.ROCKS_NVIM = "rocks.nvim"
 
 return constants
 

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -4,13 +4,40 @@
 }: final: prev: let
   lib = final.lib;
   rocks-nvim-luaPackage-override = luaself: luaprev: {
+    fidget-nvim =
+      # TODO: Replace with nixpkgs package when available
+      luaself.callPackage ({
+          buildLuarocksPackage,
+          fetchurl,
+          fetchzip,
+          lua,
+          luaOlder,
+        }:
+          buildLuarocksPackage {
+            pname = "fidget.nvim";
+            version = "1.1.0-1";
+            knownRockspec =
+              (fetchurl {
+                url = "mirror://luarocks/fidget.nvim-1.1.0-1.rockspec";
+                sha256 = "0pgjbsqp6bs9kwi0qphihwhl47j1lzdgg3xfa6msikrcf8d7j0hf";
+              })
+              .outPath;
+            src =
+              fetchzip {
+                url = "https://github.com/j-hui/fidget.nvim/archive/300018af4
+abd00610a345e382ca1f4b7ba420f77.zip";
+                sha256 = "0bwjcqkb735wqnzc8rngvpq1b2rxgc7m0arjypvnvzsxw6wd1f61";
+              };
+            propagatedBuildInputs = [lua];
+          }) {};
+
     rocks-nvim = luaself.callPackage ({
       luaOlder,
       buildLuarocksPackage,
       lua,
       toml,
       toml-edit,
-      nui-nvim,
+      fidget-nvim,
       fzy,
     }:
       buildLuarocksPackage {
@@ -22,7 +49,7 @@
         propagatedBuildInputs = [
           toml
           toml-edit
-          nui-nvim
+          fidget-nvim
           fzy
         ];
       }) {};
@@ -31,16 +58,10 @@
     packageOverrides = rocks-nvim-luaPackage-override;
   };
   lua51Packages = final.lua5_1.pkgs;
-  luajit = prev.luajit.override {
-    packageOverrides = rocks-nvim-luaPackage-override;
-  };
-  luajitPackages = final.luajit.pkgs;
 in {
   inherit
     lua5_1
     lua51Packages
-    luajit
-    luajitPackages
     ;
 
   vimPlugins =
@@ -85,7 +106,7 @@ in {
               (with lua51Packages; [
                 toml
                 toml-edit
-                nui-nvim
+                fidget-nvim
                 fzy
               ])
             }"''
@@ -93,6 +114,7 @@ in {
           + ''--suffix LUA_PATH ";" "${
               lib.concatMapStringsSep ";" lua51Packages.getLuaPath
               (with lua51Packages; [
+                fidget-nvim
                 fzy
               ])
             }"''

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -11,7 +11,7 @@
             toml-edit
             toml
             plenary-nvim
-            nui-nvim
+            fidget-nvim
             fzy
           ];
 

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     "lua >= 5.1",
     "toml-edit",
     "toml",
-    "nui.nvim",
+    "fidget.nvim >= 1.1.0",
     "fzy",
 }
 
@@ -18,7 +18,7 @@ test_dependencies = {
     "lua >= 5.1",
     "toml-edit",
     "toml",
-    "nui.nvim",
+    "fidget.nvim >= 1.1.0",
     "fzy",
 }
 


### PR DESCRIPTION
This uses the new `fidget.progress` API for reporting operations progress.

It feels a bit more modern than the current `nui` implementation, with the ability to report progress as a percentage (`update`, `sync`, ...), and show signs of life with the spinner animation.

![tty](https://github.com/nvim-neorocks/rocks.nvim/assets/12857160/5d8cb60c-1518-4feb-b853-571b6d47cb07)

For now, error handling isn't that advanced.
I plan on keeping track of errors with a log file (#55).