### PR TITLE
refactor(api): `get_rocks_toml` -> `get_rocks_toml_path`

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -121,12 +121,20 @@ api.query_installed_rocks({callback})                *api.query_installed_rocks*
         {callback}  (fun(rocks:table<rock_name,Rock>))  @async
 
 
-api.get_rocks_toml()                                        *api.get_rocks_toml*
+api.get_rocks_toml_path()                              *api.get_rocks_toml_path*
     Gets the rocks.toml file path.
     Note that the file may not have been created yet.
 
     Returns: ~
-        (string)  rocks_toml_file
+        (string)  rocks_toml_file_path
+
+
+api.get_rocks_toml()                                        *api.get_rocks_toml*
+    Returns a table with the parsed rocks.toml file.
+    If the file doesn't exist a file with the default configuration will be created.
+
+    Returns: ~
+        (table)  rocks_toml_file
 
 
 RocksCmd                                                              *RocksCmd*

--- a/lua/rocks/api.lua
+++ b/lua/rocks/api.lua
@@ -24,13 +24,15 @@
 
 local api = {}
 
-local nio = require("nio")
 local cache = require("rocks.cache")
-local luarocks = require("rocks.luarocks")
-local fzy = require("rocks.fzy")
-local state = require("rocks.state")
 local commands = require("rocks.commands")
 local config = require("rocks.config.internal")
+local constants = require("rocks.constants")
+local fs = require("rocks.fs")
+local fzy = require("rocks.fzy")
+local luarocks = require("rocks.luarocks")
+local nio = require("nio")
+local state = require("rocks.state")
 
 ---Tries to get the cached rocks.
 ---Returns an empty list if the cache has not been populated
@@ -91,9 +93,17 @@ end
 
 ---Gets the rocks.toml file path.
 ---Note that the file may not have been created yet.
----@return string rocks_toml_file
-function api.get_rocks_toml()
+---@return string rocks_toml_file_path
+function api.get_rocks_toml_path()
     return config.config_path
+end
+
+---Returns a table with the parsed rocks.toml file.
+---If the file doesn't exist a file with the default configuration will be created.
+---@return table rocks_toml_file
+function api.get_rocks_toml()
+    local config_file = fs.read_or_create(config.config_path, constants.DEFAULT_CONFIG)
+    return require("toml").decode(config_file)
 end
 
 ---@class RocksCmd


### PR DESCRIPTION
This PR modifies the existing `get_rocks_toml` function (which earlier retrieved the path) to now retrieve
the parsed TOML file. The old function has now been moved to `get_rocks_toml_path`, which naturally returns the path.

This is to allow rocks modules to easily access the contents of the rocks.toml file without having to worry about using their own parsers.