### PR TITLE
feat: auto add newly installed plugins to the RTP

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -51,6 +51,7 @@ RocksOpts                                                            *RocksOpts*
         {config_path?}      (string)   Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
         {luarocks_binary?}  (string)   Luarocks binary path. Defaults to `luarocks`.
         {lazy?}             (boolean)  Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
+        {dynamic_rtp?}      (boolean)  Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
 
 
 ==============================================================================

--- a/lua/rocks/config/check.lua
+++ b/lua/rocks/config/check.lua
@@ -36,6 +36,7 @@ function check.validate(cfg)
         config_path = { cfg.config_path, "string" },
         luarocks_binary = { cfg.luarocks_binary, "string" },
         lazy = { cfg.lazy, "boolean" },
+        dynamic_rtp = { cfg.dynamic_rtp, "boolean" },
     })
     if not ok then
         return false, err

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -18,6 +18,7 @@ local config = {}
 ---@field config_path? string Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
 ---@field luarocks_binary? string Luarocks binary path. Defaults to `luarocks`.
 ---@field lazy? boolean Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
+---@field dynamic_rtp? boolean Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
 
 ---@type RocksOpts | fun():RocksOpts
 vim.g.rocks_nvim = vim.g.rocks_nvim

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -20,6 +20,7 @@
 ---@field config_path string Rocks declaration file path
 ---@field luarocks_binary string Luarocks binary path
 ---@field lazy boolean Whether to query luarocks.org lazily.
+---@field dynamic_rtp boolean Whether to automatically add freshly installed plugins to the 'runtimepath'.
 ---@field debug_info RocksConfigDebugInfo
 
 ---@class (exact) RocksConfigDebugInfo
@@ -35,6 +36,7 @@ local default_config = {
     config_path = vim.fs.joinpath(vim.fn.stdpath("config"), "rocks.toml"),
     luarocks_binary = "luarocks",
     lazy = false,
+    dynamic_rtp = true,
     debug_info = {
         was_g_rocks_nvim_sourced = vim.g.rocks_nvim ~= nil,
         unrecognized_configs = {},

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -97,6 +97,9 @@ operations.install = function(name, version, progress_handle)
             if progress_handle then
                 progress_handle:report({ message = message })
             end
+
+            vim.opt.runtimepath:append(vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", installed_rock.name:lower()))
+
             future.set(installed_rock)
         end
     end)
@@ -305,6 +308,8 @@ operations.sync = function(user_rocks)
                 percentage = get_progress_percentage(),
                 message = is_downgrading and ("Downgraded: %s"):format(key) or ("Upgraded: %s"):format(key),
             })
+
+            vim.opt.runtimepath:append(vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", user_rocks[key].name:lower()))
         end
 
         -- Determine dependencies of installed user rocks, so they can be excluded from rocks to prune

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -308,8 +308,6 @@ operations.sync = function(user_rocks)
                 percentage = get_progress_percentage(),
                 message = is_downgrading and ("Downgraded: %s"):format(key) or ("Upgraded: %s"):format(key),
             })
-
-            vim.opt.runtimepath:append(vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", user_rocks[key].name:lower()))
         end
 
         -- Determine dependencies of installed user rocks, so they can be excluded from rocks to prune

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -98,7 +98,11 @@ operations.install = function(name, version, progress_handle)
                 progress_handle:report({ message = message })
             end
 
-            vim.opt.runtimepath:append(vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", installed_rock.name:lower()))
+            if config.dynamic_rtp then
+                vim.opt.runtimepath:append(
+                    vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", installed_rock.name:lower())
+                )
+            end
 
             future.set(installed_rock)
         end


### PR DESCRIPTION
This PR adds freshly installed plugins to the runtimepath so they can be used right away.

TODOs:
- [x] Make this configurable within the rocks options

This approach theoretically adds more than usually required to the RTP (as by default we use a glob over all installed plugins), however this is only for the current session (which is a good tradeoff in my opinion) and makes sure everything works smoothly.