### PR TITLE
chore(nix): use test suite as base for devShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 result
+https___luarocks.org/
+https___nvim-neorocks.github.io_rocks-binaries/
 .pre-commit-config.yaml
 .direnv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,16 @@ Or
 
 - [`nlua`](https://github.com/mfussenegger/nlua).
 
+> [!NOTE]
+>
+> The Nix devShell sets up `luarocks test` to use Neovim as the interpreter.
+
 ### Running tests and checks with Nix
 
 If you just want to run all checks that are available, run:
 
 ```console
-nix flake check -L
+nix flake check -L --option sandbox false
 ```
 
 To run tests locally, using Nix:

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
           };
         };
 
-        devShell = pkgs.mkShell {
+        devShell = pkgs.integration-nightly.overrideAttrs (oa: {
           name = "rocks.nvim devShell";
           inherit (pre-commit-check) shellHook;
           buildInputs = with pre-commit-hooks.packages.${system};
@@ -134,11 +134,9 @@
               luacheck
               editorconfig-checker
             ]
-            ++ (with pkgs; [
-              lua5_1
-              luarocks
-            ]);
-        };
+            ++ oa.buildInputs;
+          doCheck = false;
+        });
       in {
         devShells = {
           default = devShell;


### PR DESCRIPTION
This allows us to run `luarocks test` with Neovim as the interpreter from within the devShell.