### PR TITLE
feat(api): allow external modules to hook into `:Rocks sync`

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -5,6 +5,7 @@ rocks.nvim ··································�
 rocks.nvim commands ··········································· |rocks.commands|
 rocks.nvim configuration ········································ |rocks.config|
 rocks.nvim Lua API ················································· |rocks.api|
+rocks.nvim logging API ············································· |rocks.log|
 
 ==============================================================================
 rocks.nvim                                                               *rocks*
@@ -62,17 +63,17 @@ The Lua API for rocks.nvim.
 Intended for use by modules that extend this plugin.
 
 
-Rock                                                                      *Rock*
-
-    Fields: ~
-        {name}     (string)
-        {version}  (string)
-
-
 rock_name                                                            *rock_name*
 
     Type: ~
         string
+
+
+Rock                                                                      *Rock*
+
+    Fields: ~
+        {name}     (rock_name)
+        {version}  (string)
 
 
 api.try_get_cached_rocks()                            *api.try_get_cached_rocks*
@@ -152,6 +153,57 @@ api.register_rocks_subcommand({name}, {cmd})
     Parameters: ~
         {name}  (string)    The name of the subcommand to register
         {cmd}   (RocksCmd)
+
+
+RockSpec                                                              *RockSpec*
+
+
+        { name: rock_name, version?: string, [string]: V }
+
+Specification for a rock in rocks.toml.
+
+rock_handler_callback                                    *rock_handler_callback*
+
+    Type: ~
+        fun(report_progress:fun(message:string),report_error:fun(message:string))
+
+
+A function that operates on the rock, syncing it with the entry in rocks.toml
+
+RockHandler                                                        *RockHandler*
+
+    Fields: ~
+        {get_sync_callback}   (fun(spec:RockSpec):rock_handler_callback|nil)                    Return a function that installs or updates the rock, or `nil` if the handler cannot or does not need to sync the rock.
+        {get_prune_callback}  (fun(specs:table<rock_name,RockSpec>):rock_handler_callback|nil)  Return a function that prunes unused rocks, or `nil` if the handler cannot or does not need to prune any rocks.
+
+
+api.register_rock_handler({handler})                 *api.register_rock_handler*
+
+    Parameters: ~
+        {handler}  (RockHandler)
+
+
+==============================================================================
+rocks.nvim logging API                                               *rocks.log*
+
+
+The logging interface for rocks.nvim.
+Intended to be used by external modules.
+
+
+log.trace()                                                          *log.trace*
+
+
+log.debug()                                                          *log.debug*
+
+
+log.info()                                                            *log.info*
+
+
+log.warn()                                                            *log.warn*
+
+
+log.error()                                                          *log.error*
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/rocks/api.lua
+++ b/lua/rocks/api.lua
@@ -16,11 +16,11 @@
 -- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
 -- Maintainer: NTBBloodbath <bloodbathalchemist@protonmail.com>
 
----@class Rock
----@field name string
----@field version string
-
 ---@alias rock_name string
+
+---@class Rock
+---@field name rock_name
+---@field version string
 
 local api = {}
 
@@ -33,6 +33,7 @@ local fzy = require("rocks.fzy")
 local luarocks = require("rocks.luarocks")
 local nio = require("nio")
 local state = require("rocks.state")
+local operations = require("rocks.operations")
 
 ---Tries to get the cached rocks.
 ---Returns an empty list if the cache has not been populated
@@ -115,6 +116,27 @@ end
 ---@param cmd RocksCmd
 function api.register_rocks_subcommand(name, cmd)
     commands.register_subcommand(name, cmd)
+end
+
+---@class RockSpec: { name: rock_name, version?: string, [string]: any }
+---@brief [[
+---        { name: rock_name, version?: string, [string]: V }
+---
+---Specification for a rock in rocks.toml.
+---@brief ]]
+
+---@alias rock_handler_callback fun(report_progress: fun(message: string), report_error: fun(message: string))
+---@brief [[
+---A function that operates on the rock, syncing it with the entry in rocks.toml
+---@brief ]]
+
+---@class RockHandler
+---@field get_sync_callback fun(spec: RockSpec):rock_handler_callback|nil Return a function that installs or updates the rock, or `nil` if the handler cannot or does not need to sync the rock.
+---@field get_prune_callback fun(specs: table<rock_name, RockSpec>):rock_handler_callback|nil Return a function that prunes unused rocks, or `nil` if the handler cannot or does not need to prune any rocks.
+
+---@param handler RockHandler
+function api.register_rock_handler(handler)
+    operations.register_handler(handler)
 end
 
 return api

--- a/lua/rocks/log.lua
+++ b/lua/rocks/log.lua
@@ -1,8 +1,9 @@
----@mod rocks.log rocks.nvim logging
+---@mod rocks.log rocks.nvim logging API
 ---
 ---@brief [[
 ---
----The internal logging interface for rocks.nvim
+---The logging interface for rocks.nvim.
+---Intended to be used by external modules.
 ---
 ---@brief ]]
 
@@ -15,15 +16,21 @@
 -- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
 -- Maintainer: NTBBloodbath <bloodbathalchemist@protonmail.com>
 
-local log = {
-    -- NOTE: These functions are initialised as empty for type checking purposes
-    -- and implemented later.
-    trace = function(_) end,
-    debug = function(_) end,
-    info = function(_) end,
-    warn = function(_) end,
-    error = function(_) end,
-}
+local log = {}
+
+-- NOTE: These functions are initialised as empty for type checking purposes
+-- and implemented later.
+
+---@type fun(any)
+function log.trace(_) end
+---@type fun(any)
+function log.debug(_) end
+---@type fun(any)
+function log.info(_) end
+---@type fun(any)
+function log.warn(_) end
+---@type fun(any)
+function log.error(_) end
 
 local LARGE = 1e9
 
@@ -37,20 +44,22 @@ end
 local logfilename = vim.fn.tempname() .. "-rocks-nvim.log"
 
 ---Get the rocks.nvim log file path.
+---@package
 ---@return string filepath
 function log.get_logfile()
     return logfilename
 end
 
 ---Open the rocks.nvim log file.
+---@package
 function log.open_logfile()
     vim.cmd.e(log.get_logfile())
 end
 
 local logfile, openerr
---- @private
---- Opens log file. Returns true if file is open, false on error
---- @return boolean
+---@private
+---Opens log file. Returns true if file is open, false on error
+---@return boolean
 local function open_logfile()
     -- Try to open file only once
     if logfile then
@@ -79,9 +88,10 @@ local function open_logfile()
     return true
 end
 
---- Set the log level
---- @param level (string|integer) The log level
---- @see vim.log.levels
+---Set the log level
+---@param level (string|integer) The log level
+---@see vim.log.levels
+---@package
 function log.set_level(level)
     local log_levels = vim.deepcopy(vim.log.levels)
     vim.tbl_add_reverse_lookup(log_levels)

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -33,7 +33,7 @@
     ];
     text = ''
       mkdir -p doc
-      lemmy-help lua/rocks/{init,commands,config/init,api}.lua > doc/rocks.txt
+      lemmy-help lua/rocks/{init,commands,config/init,api,log}.lua > doc/rocks.txt
     '';
   };
 in {


### PR DESCRIPTION
... in preparation for #81.

This is ready to be reviewed, but I'd prefer to leave it as a draft and not to merge it until we have a basic working implementation of a module that uses this API.

I initially wanted the API to allow hooking into the `update`, `sync` and `prune` commands.
But after playing around with the idea, I think `sync` is enough. 

Hooking into `update` and `prune` might be a bad idea, for the following reasons:

- `update` uses the luarocks state to determine the outdated rocks, and then updates the rocks.toml (parsed with `toml-edit`).
   Hooking into `update` would require parsing the config with `toml`, and potentially allowing to update the config with `toml-edit`.
   This adds a whole lot of complexity. 
- Like `update`, `prune` parses and modifies the config with `toml-edit`. Hooking into it would add complexity.
- The `rocks-git` module is meant to be a bridge for making rocks.nvim adoption less painful while there aren't many plugins on luarocks. I don't think it's desirable to implement features like globs on tags (people can use Lazy for that).
  If we do end up needing those features, it would be better for the module to implement its own commands (e.g. `:Rocks gitPull`).

In terms of the `rocks-git` module, we can treat `sync` as follows:

- Pull if there is no `rev` or `tag` field, as this typically means the user wants the `HEAD` of the main branch.
- Checkout a `rev` or `tag` if one is specified.

  