### PR TITLE
refactor(installer): only add rocks.nvim to rtp in install script

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -396,7 +396,7 @@ local function install()
                     " }",
                     ' package.cpath = package.cpath .. ";" .. table.concat(luarocks_cpath, ";")',
                     " ",
-                    ' vim.opt.runtimepath:append(vim.fs.joinpath(rocks_config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", "*"))',
+                    ' vim.opt.runtimepath:append(vim.fs.joinpath(rocks_config.rocks_path, "lib", "luarocks", "rocks-5.1", "rocks.nvim", "*"))',
                     "<",
                     "Thank you for installing rocks.nvim!",
                     "",

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -19,8 +19,8 @@
 ---@field rocks_path string Local path in your filesystem to install rocks
 ---@field config_path string Rocks declaration file path
 ---@field luarocks_binary string Luarocks binary path
----@field lazy boolean Whether to query luarocks.org lazily.
----@field dynamic_rtp boolean Whether to automatically add freshly installed plugins to the 'runtimepath'.
+---@field lazy boolean Whether to query luarocks.org lazily
+---@field dynamic_rtp boolean Whether to automatically add freshly installed plugins to the 'runtimepath'
 ---@field debug_info RocksConfigDebugInfo
 
 ---@class (exact) RocksConfigDebugInfo

--- a/nix/init.lua
+++ b/nix/init.lua
@@ -20,4 +20,4 @@ local luarocks_cpath = {
 }
 package.cpath = package.cpath .. ";" .. table.concat(luarocks_cpath, ";")
 
-vim.opt.runtimepath:append(vim.fs.joinpath(rocks_config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", "*"))
+vim.opt.runtimepath:append(vim.fs.joinpath(rocks_config.rocks_path, "lib", "luarocks", "rocks-5.1", "rocks.nvim", "*"))

--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -17,3 +17,6 @@ if not config.lazy then
         })
     end)
 end
+
+-- TODO: Add support for `opt`
+vim.opt.runtimepath:append(vim.fs.joinpath(config.rocks_path, "lib", "luarocks", "rocks-5.1", "*", "*"))


### PR DESCRIPTION
This is in preparation for #86.
For now, no behaviour has changed. `rocks.nvim` still adds all plugins to the rtp on startup.