### PR TITLE
fix: better stack traces

### DIFF
--- a/lua/rocks/runtime.lua
+++ b/lua/rocks/runtime.lua
@@ -68,8 +68,10 @@ local function source(rtp_source_dir, dir)
     for script, name, ty in iter_children(rtp_dir) do
         local ext = name:sub(-3)
         if vim.tbl_contains({ "file", "link" }, ty) and vim.tbl_contains({ "lua", "vim" }, ext) then
-            local ok, err = pcall(vim.cmd.source, script)
-            if not ok and type(err) == "string" then
+            local co = coroutine.create(vim.cmd.source)
+            local ok = coroutine.resume(co, script)
+            if not ok then
+                local err = debug.traceback(co, "rocks.nvim: Error to sourcing " .. name)
                 log.error(err)
                 vim.notify(err, vim.log.levels.ERROR)
                 break

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -109,9 +109,12 @@ state.rock_dependencies = nio.create(function(rock)
         end
     end, { text = true })
 
-    local success, result = pcall(future.wait)
+    local co = coroutine.create(function()
+        coroutine.yield(future.wait())
+    end)
+    local success, result = coroutine.resume(co)
     if not success then
-        log.error(result)
+        log.error(debug.traceback(co))
         return {}
     end
 


### PR DESCRIPTION
`pcall` unwinds the stack when it fails, so we lose the stack trace. Moving the code to a different
coroutine allows us to notify/log the stack trace
that we're actually interested in.