### PR TITLE
fix(update,install): rocks.toml entries coerced to strings

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -31,7 +31,7 @@ jobs:
           version: ${{ env.LUAROCKS_VERSION }}
           test_interpreters: ""
           dependencies: |
-            toml-edit
+            toml-edit >= 0.1.5
             toml
             fidget.nvim >= 1.1.0
             fzy

--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1703481787,
-        "narHash": "sha256-0lDpYLQfSNA6KGfA3+OL9PNoK2Dhk8hmcaaYB79kIfU=",
+        "lastModified": 1703827325,
+        "narHash": "sha256-d18cvH6LP4iCDwE823vLqjusuLjCPDZpUBY5RhhykZo=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "8b1acf09a40d3bf725ace436278cd2cb6eea0b55",
+        "rev": "e4f1b7dd18a0de26620ab2420b28205ab2f396b4",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1703470873,
-        "narHash": "sha256-If+BALE8m4qx8Lqn0wRACWjPe/x/7ZoVpgaZeOPOa30=",
+        "lastModified": 1703807649,
+        "narHash": "sha256-Cqm5aejScs6pxEFCwwiHisF9Qg1BbGihcYIFtaXHAjk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2877672d70e76f71ae1190090b8aea7044d458be",
+        "rev": "1ef60ea6513be72a03958ed6239bfe474c85a7a3",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703134684,
-        "narHash": "sha256-SQmng1EnBFLzS7WSRyPM9HgmZP2kLJcPAz+Ug/nug6o=",
+        "lastModified": 1703499205,
+        "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6863cbcbbb80e71cecfc03356db1cda38919523",
+        "rev": "e1fa12d4f6c6fe19ccb59cac54b5b3f25e160870",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703547242,
-        "narHash": "sha256-huIqSS810+Z1lDVAatrn0Tptp5XYZXDPBBPI9PG/bI4=",
+        "lastModified": 1703879592,
+        "narHash": "sha256-6DWQHP26qY/no12ntjnderTeAe9IYbQfjSl//E+1rd8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "904b22f4024a67b196eda237e8b7cdd2fd4fe7ee",
+        "rev": "08a62091a13d6ce63fb319a2673da65f2ce77a7f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,8 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            plugin-overlay
             neorocks.overlays.default
+            plugin-overlay
             test-overlay
           ];
         };

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -491,7 +491,15 @@ operations.update = function()
                     percentage = get_percentage(ct, #outdated_rocks),
                 })
             end
-            user_rocks.plugins[ret.name] = ret.version
+            ---@type rock_name
+            local rock_name = ret.name
+            local user_rock = user_rocks.plugins[rock_name]
+            if user_rock and user_rock.version then
+                -- Rock is configured as a table -> Update version.
+                user_rocks.plugins[rock_name].version = ret.version
+            else
+                user_rocks.plugins[rock_name] = ret.version
+            end
             progress_handle:report({
                 message = ("Updated %s: %s -> %s"):format(rock.name, rock.version, rock.target_version),
                 percentage = get_percentage(ct, #outdated_rocks),
@@ -568,7 +576,13 @@ operations.add = function(rock_name, version)
             if version == "dev" then
                 installed_rock.version = "scm-1"
             end
-            user_rocks.plugins[installed_rock.name] = installed_rock.version
+            local user_rock = user_rocks.plugins[rock_name]
+            if user_rock and user_rock.version then
+                -- Rock already exists in rock.toml and is configured as a table -> Update version.
+                user_rocks.plugins[rock_name].version = installed_rock.version
+            else
+                user_rocks.plugins[rock_name] = installed_rock.version
+            end
             fs.write_file(config.config_path, "w", tostring(user_rocks))
             if success then
                 progress_handle:finish()

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -4,6 +4,48 @@
 }: final: prev: let
   lib = final.lib;
   rocks-nvim-luaPackage-override = luaself: luaprev: {
+    toml-edit =
+      (luaself.callPackage ({
+        buildLuarocksPackage,
+        fetchgit,
+        fetchurl,
+        lua,
+        luaOlder,
+        luarocks-build-rust-mlua,
+      }:
+        buildLuarocksPackage {
+          pname = "toml-edit";
+          version = "0.1.5-1";
+          knownRockspec =
+            (fetchurl {
+              url = "mirror://luarocks/toml-edit-0.1.5-1.rockspec";
+              sha256 = "1xgjh8x44kn24vc29si811zq2a7pr24zqj4w07pys5k6ccnv26qz";
+            })
+            .outPath;
+          src = fetchgit (removeAttrs (builtins.fromJSON ''            {
+              "url": "https://github.com/vhyrro/toml-edit.lua",
+              "rev": "34f072d8ff054b3124d9d2efc0263028d7425525",
+              "date": "2023-12-29T15:53:36+01:00",
+              "path": "/nix/store/z1gn59hz9ypk3icn3gmafaa19nzx7a1v-toml-edit.lua",
+              "sha256": "0jzzp4sd48haq1kmh2k85gkygfq39i10kvgjyqffcrv3frdihxvx",
+              "hash": "sha256-fXcYW3ZjZ+Yc9vLtCUJMA7vn5ytoClhnwAoi0jS5/0s=",
+              "fetchLFS": false,
+              "fetchSubmodules": true,
+              "deepClone": false,
+              "leaveDotGit": false
+            }
+          '') ["date" "path" "sha256"]);
+
+          propagatedBuildInputs = [lua luarocks-build-rust-mlua];
+        }) {})
+      .overrideAttrs (oa: {
+        cargoDeps = final.rustPlatform.fetchCargoTarball {
+          src = oa.src;
+          hash = "sha256-gvUqkLOa0WvAK4GcTkufr0lC2BOs2FQ2bgFpB0qa47k=";
+        };
+        nativeBuildInputs = with final; [cargo rustPlatform.cargoSetupHook] ++ oa.nativeBuildInputs;
+      });
+
     nvim-nio =
       # TODO: Replace with nixpkgs package when available
       luaself.callPackage ({

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -8,7 +8,7 @@ version = _MODREV .. _SPECREV
 
 dependencies = {
     "lua >= 5.1",
-    "toml-edit",
+    "toml-edit >= 0.1.5",
     "toml",
     "fidget.nvim >= 1.1.0",
     "fzy",
@@ -17,7 +17,7 @@ dependencies = {
 
 test_dependencies = {
     "lua >= 5.1",
-    "toml-edit",
+    "toml-edit >= 0.1.5",
     "toml",
     "fidget.nvim >= 1.1.0",
     "fzy",


### PR DESCRIPTION
Manual test steps:

- `nix run .#neovim-with-rocks -- -c "Rocks edit"`
- Add the following entry: `"haskell-tools.nvim" = { version = "3.0.0", opt = true }`
- `:Rocks sync`
- `:Rocks update`

-> Updates the entry to `"haskell-tools.nvim" = { version = "3.1.1", opt = true }`