### PR TITLE
feat: settings.lazy for disabling plugin loading

### DIFF
--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -48,7 +48,7 @@ local default_config = {
         local config_file = fs.read_or_create(config.config_path, constants.DEFAULT_CONFIG)
         local rocks_toml = require("toml").decode(config_file)
         for key, tbl in pairs(rocks_toml) do
-            if key == "rocks" or key == "plugins" then
+            if key == "rocks" or key == "plugins" or key == "settings" then
                 for name, data in pairs(tbl) do
                     if type(data) == "string" then
                         ---@type RockSpec
@@ -69,6 +69,10 @@ local default_config = {
         local rocks_toml = config.get_rocks_toml()
         return vim.tbl_deep_extend("force", rocks_toml.rocks or {}, rocks_toml.plugins or {})
     end,
+    get_user_settings = function()
+        local rocks_toml = config.get_rocks_toml()
+        return rocks_toml.settings or {}
+    end
 }
 
 ---@type RocksOpts

--- a/lua/rocks/runtime.lua
+++ b/lua/rocks/runtime.lua
@@ -150,12 +150,16 @@ function runtime.packadd(rock_name, opts)
     source_ftdetect(path)
 end
 
----Source all plugins with `opt ~= true`
+---Source all plugins with `opt ~= true` unless settings.lazy is set to true
 ---NOTE: We don't want this to be async,
 ---to ensure Neovim sources `after/plugin` scripts
 ---after we source start plugins.
 function runtime.source_start_plugins()
     local user_rocks = config.get_user_rocks()
+    local user_settings = config.get_user_settings()
+    if user_settings.lazy and user_settings.lazy == "true" then
+        return
+    end
     for _, rock_spec in pairs(user_rocks) do
         if not rock_spec.opt and rock_spec.version and rock_spec.name ~= constants.ROCKS_NVIM then
             -- Append to rtp first in case a plugin needs another plugin's `autoload`


### PR DESCRIPTION
Problem: Sometimes one wants *non* of the plugins to be sourced on `rocks.nvim` startup, but adding `opt = false` for all the plugins is tiresome

Solution: introduces a `settings` header, with a `lazy` field, if that is true, we wouldn't source any plugins on startup

What do you guys think 🤔 ?