### PR TITLE
docs(readme): add tip to configure luarocks install with envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ nvim -u NORC -c "source https://raw.githubusercontent.com/nvim-neorocks/rocks.nv
 
 > [!TIP]
 >
-> In order to configure luarocks installation to use a specific lua install,
+> To configure the luarocks installation to use a specific lua install,
 > use environment variables `LUA_BINDIR=<Directory of lua binary>` and `LUA_BINDIR_SET=yes`.
 >
 > For example:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ nvim -u NORC -c "source https://raw.githubusercontent.com/nvim-neorocks/rocks.nv
 > For security reasons, we recommend that you read `:help :source`
 > and the installer code before running it so you know exactly what it does.
 
+> [!TIP]
+>
+> In order to configure luarocks installation to use a specific lua install,
+> use environment variables `LUA_BINDIR=<Directory of lua binary>` and `LUA_BINDIR_SET=yes`.
+>
+> For example:
+>
+> `LUA_BINDIR="${XDG_BIN_DIR:-$HOME/.local/bin}" LUA_BINDIR_SET=yes nvim -u NORC -c "source ...`
+
 ## :books: Usage
 
 ### Installing rocks


### PR DESCRIPTION
When lua and luajit is not installed via the system package manager, luarocks build script 
fails to detect the lua runtime, which results in a fail. 

![image](https://github.com/nvim-neorocks/rocks.nvim/assets/41065736/43b08f44-f8fa-40c8-8b5e-f73c6e0cbf1f)

Usually, we can `./configure` with options such as `--with-lua` ([cli options](https://github.com/luarocks/luarocks/wiki/Installation-instructions-for-Unix#customizing-your-settings)), but as this is run in the background, I cannot edit these options, or I would need to add a new field in the UI which is kinda hassle. 

Luarocks build scripts uses variables such as `LUA_DIR`, so we can trick the script by providing these varibles from outside. 
To workaround this issue, I added a `[!TIP]` in the README for other people who came across the same issue.

---

> [!TIP]
>
> In order to configure luarocks installation to use a specific lua install,
> use environment variables `LUA_BINDIR=<Directory of lua binary>` and `LUA_BINDIR_SET=yes`.
>
> For example:
>
> `LUA_BINDIR="${XDG_BIN_DIR:-$HOME/.local/bin}" LUA_BINDIR_SET=yes nvim -u NORC -c "source ...`
