### PR TITLE
chore(constants.lua): update version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,8 @@
 The days of bootstrapping and editing your configuration are over.
 `rocks.nvim` can be installed directly through an interactive installer within Neovim.
 
-You just have to run the following command inside your editor
-and the installer will do the rest!
-
-```vim
-:source https://raw.githubusercontent.com/nvim-neorocks/rocks.nvim/master/installer.lua
-```
-
-If you already have plugins installed, we suggest running the installer
-without loading RC files, as some plugins may interfere with the script:
+We suggest starting nvim without loading RC files, such that already installed plugins do not interfere
+with the installer:
 
 ```sh
 nvim -u NORC -c "source https://raw.githubusercontent.com/nvim-neorocks/rocks.nvim/master/installer.lua"


### PR DESCRIPTION
twice on different computers I tried the first advised command:

`:source https://raw.githubusercontent.com/nvim-neorocks/rocks.nvim/master/installer.lua` which prompts:
E484: Can't open file https://raw.githubusercontent.com/nvim-neorocks/rocks.nvim/master/installer.lua

This is a quite diconcerting error message and not easy to troubleshoot imo. In my case seems like it was oil.nvim.

The README is already long so I suggest that instead of having one command that might work and one command that works we keep the command that works even if the user has to run a non-customized nvim. It's easier for him to go from the 2nd command to the first one, and even in the NORC one, it wont be long, just the time to run the installer.