### PR TITLE
ci: add signoff input to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,9 +10,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
         with:
           release-type: simple
           package-name: rocks.nvim
+          signoff: "Marc Jakobi<marc@jakobi.dev>"


### PR DESCRIPTION
This should ensure that the luarocks upload action is triggered automatically on release