### PR TITLE
ci: add concurrency key to review checklist action

### DIFF
--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [opened, review_requested]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   review-checklist:
     name: Review Checklist


### PR DESCRIPTION
This should prevent the review checklist bot from commenting mroe than once per PR