### PR TITLE
feat: generate plugins help pages tags on install/update

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -57,11 +57,12 @@ rocks.nvim configuration                                          *rocks.config*
 RocksOpts                                                            *RocksOpts*
 
     Fields: ~
-        {rocks_path?}       (string)   Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
-        {config_path?}      (string)   Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
-        {luarocks_binary?}  (string)   Luarocks binary path. Defaults to `luarocks`.
-        {lazy?}             (boolean)  Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
-        {dynamic_rtp?}      (boolean)  Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
+        {rocks_path?}           (string)   Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
+        {config_path?}          (string)   Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
+        {luarocks_binary?}      (string)   Luarocks binary path. Defaults to `luarocks`.
+        {lazy?}                 (boolean)  Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
+        {dynamic_rtp?}          (boolean)  Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
+        {generate_help_pages?}  (boolean)  Whether to re-generate plugins help pages after installation/upgrade.
 
 
 ==============================================================================

--- a/lua/rocks/config/check.lua
+++ b/lua/rocks/config/check.lua
@@ -37,6 +37,7 @@ function check.validate(cfg)
         luarocks_binary = { cfg.luarocks_binary, "string" },
         lazy = { cfg.lazy, "boolean" },
         dynamic_rtp = { cfg.dynamic_rtp, "boolean" },
+        generate_help_pages = { cfg.generate_help_pages, "boolean" },
     })
     if not ok then
         return false, err

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -19,6 +19,7 @@ local config = {}
 ---@field luarocks_binary? string Luarocks binary path. Defaults to `luarocks`.
 ---@field lazy? boolean Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
 ---@field dynamic_rtp? boolean Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
+---@field generate_help_pages? boolean Whether to re-generate plugins help pages after installation/upgrade.
 
 ---@type RocksOpts | fun():RocksOpts
 vim.g.rocks_nvim = vim.g.rocks_nvim

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -36,6 +36,8 @@ local default_config = {
     lazy = false,
     ---@type boolean Whether to automatically add freshly installed plugins to the 'runtimepath'
     dynamic_rtp = true,
+    ---@type boolean Whether to re-generate plugins help pages after installation/upgrade
+    generate_help_pages = true,
     ---@class RocksConfigDebugInfo
     debug_info = {
         ---@type boolean

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -127,7 +127,7 @@ operations.install = function(rock_spec, progress_handle)
 
             -- Re-generate help tags
             if config.generate_help_pages then
-                vim.cmd("heltags ALL")
+                vim.cmd("helptags ALL")
             end
 
             future.set(installed_rock)
@@ -446,7 +446,7 @@ operations.sync = function(user_rocks)
 
         -- Re-generate help tags
         if config.generate_help_pages then
-            vim.cmd("heltags ALL")
+            vim.cmd("helptags ALL")
         end
     end)
 end
@@ -542,7 +542,7 @@ operations.update = function()
 
         -- Re-generate help tags
         if config.generate_help_pages then
-            vim.cmd("heltags ALL")
+            vim.cmd("helptags ALL")
         end
     end)
 end

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -125,11 +125,6 @@ operations.install = function(rock_spec, progress_handle)
                 runtime.packadd(name)
             end
 
-            -- Re-generate help tags
-            if config.generate_help_pages then
-                vim.cmd("helptags ALL")
-            end
-
             future.set(installed_rock)
         end
     end)
@@ -607,6 +602,11 @@ operations.add = function(rock_name, version)
             end
         end)
         cache.populate_removable_rock_cache()
+
+        -- Re-generate help tags
+        if config.generate_help_pages then
+            vim.cmd("helptags ALL")
+        end
     end)
 end
 

--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -125,6 +125,11 @@ operations.install = function(rock_spec, progress_handle)
                 runtime.packadd(name)
             end
 
+            -- Re-generate help tags
+            if config.generate_help_pages then
+                vim.cmd("heltags ALL")
+            end
+
             future.set(installed_rock)
         end
     end)
@@ -438,6 +443,11 @@ operations.sync = function(user_rocks)
             progress_handle:finish()
         end
         cache.populate_removable_rock_cache()
+
+        -- Re-generate help tags
+        if config.generate_help_pages then
+            vim.cmd("heltags ALL")
+        end
     end)
 end
 
@@ -529,6 +539,11 @@ operations.update = function()
             progress_handle:finish()
         end
         cache.populate_removable_rock_cache()
+
+        -- Re-generate help tags
+        if config.generate_help_pages then
+            vim.cmd("heltags ALL")
+        end
     end)
 end
 


### PR DESCRIPTION
This PR also adds a new configuration option called `generate_help_pages`, which defaults to `true`.

