### PR TITLE
build(nix): remove .luarc.json and generate one in nix devShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ https___luarocks.org/
 https___nvim-neorocks.github.io_rocks-binaries/
 .pre-commit-config.yaml
 .direnv
+.luarc.json

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-    "Lua.diagnostics.globals": [
-        "vim"
-    ]
-}

--- a/flake.lock
+++ b/flake.lock
@@ -66,6 +66,24 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -138,6 +156,25 @@
         "type": "github"
       }
     },
+    "gen-luarc": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1708687654,
+        "narHash": "sha256-8Op8BKZM6RFxZxid7E8PgRzLey9vpeNqAJkoT9IkWvc=",
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "rev": "e4a989664303d812eb4d18a98cd1ebf44e29463e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -186,15 +223,15 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1708147252,
-        "narHash": "sha256-+WK7viTZzmKkljZYz2Ef2bKujOtT0f1PpLDFVak8GlQ=",
+        "lastModified": 1708665754,
+        "narHash": "sha256-vNNaMDV3TN7fCUMWawMX+EfsDGxeu0YQ4zzZZrT3SVM=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "fc029565ca5ba3a2a2fb1cd2a47c82a153ffce61",
+        "rev": "57fa3d66f43b4b60af180597a449f28b1b483f3c",
         "type": "github"
       },
       "original": {
@@ -213,11 +250,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708130735,
-        "narHash": "sha256-8i9CMKCXOZlTuMK6oWUeLFn8IkaEYwsuTVJ703+e6wA=",
+        "lastModified": 1708647166,
+        "narHash": "sha256-qRRv4bLd59uQaOuGiD8W1SRsS2hiBBdIWUYYU1lySo4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "848fc8ede84b9cfc4e651e0e3b449060a8a8d70c",
+        "rev": "eb4783fb6c8c16d3a9a10e5ef36312737fc9bc40",
         "type": "github"
       },
       "original": {
@@ -229,21 +266,39 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708093448,
-        "narHash": "sha256-gohEm3/NVyu7WINFhRf83yJH8UM2ie/KY9Iw3VN6fiE=",
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7763249f02b7786b4ca36e13a4d7365cfba162f",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
         "lastModified": 1706550542,
@@ -295,11 +350,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708217174,
-        "narHash": "sha256-dYYyPLj1aDEXmfqECOuavHH2CWo/UrU8U590LvWyHX0=",
+        "lastModified": 1708564076,
+        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "347a8ce65b6747babcd4e037314f6c6565912c2a",
+        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1708687571,
+        "narHash": "sha256-IItC4sMcvIXI7RYKu2LcYm9TAJnbjClm+SU75IQdIlw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0c1995cc0332a7d93b09f1e5da1d9d28b153f681",
         "type": "github"
       },
       "original": {
@@ -360,8 +431,9 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "pre-commit-hooks": "pre-commit-hooks_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
 
     neorocks.url = "github:nvim-neorocks/neorocks";
 
+    gen-luarc.url = "github:mrcjkb/nix-gen-luarc-json";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     pre-commit-hooks = {
@@ -23,6 +25,7 @@
     self,
     nixpkgs,
     neorocks,
+    gen-luarc,
     flake-parts,
     pre-commit-hooks,
     ...
@@ -53,62 +56,36 @@
           inherit system;
           overlays = [
             neorocks.overlays.default
+            gen-luarc.overlays.default
             plugin-overlay
             test-overlay
           ];
         };
 
-        mkTypeCheck = {
-          nvim-api ? [],
-          disabled-diagnostics ? [],
-        }:
-          pre-commit-hooks.lib.${system}.run {
-            src = self;
-            hooks = {
-              lua-ls.enable = true;
-            };
-            settings = {
-              lua-ls = {
-                config = {
-                  runtime.version = "LuaJIT";
-                  Lua = {
-                    workspace = {
-                      library =
-                        nvim-api
-                        ++ (with pkgs.lua51Packages; [
-                          "${toml-edit}/lib/lua/5.1/"
-                          "${toml}/lib/lua/5.1/"
-                          "${fidget-nvim}/share/lua/5.1"
-                          "${fzy}/share/lua/5.1"
-                        ])
-                        ++ [
-                          "\${3rd}/busted/library"
-                          "\${3rd}/luassert/library"
-                        ];
-                      ignoreDir = [
-                        ".git"
-                        ".github"
-                        ".direnv"
-                        "result"
-                        "nix"
-                        "doc"
-                      ];
-                    };
-                    diagnostics = {
-                      libraryFiles = "Disable";
-                      disable = disabled-diagnostics;
-                    };
-                  };
-                };
-              };
-            };
-          };
-
-        type-check-nightly = mkTypeCheck {
-          nvim-api = [
-            "${pkgs.neovim-nightly}/share/nvim/runtime/lua"
-            "${pkgs.vimPlugins.neodev-nvim}/types/nightly"
+        luarc = pkgs.mk-luarc {
+          nvim = pkgs.neovim-nightly;
+          neodev-types = "nightly";
+          plugins = with pkgs.lua51Packages; [
+            toml-edit
+            toml
+            fidget-nvim
+            fzy
+            nvim-nio
           ];
+          disabled-diagnostics = [
+            # caused by a nio luaCATS bug
+            "redundant-return-value"
+          ];
+        };
+
+        type-check-nightly = pre-commit-hooks.lib.${system}.run {
+          src = self;
+          hooks = {
+            lua-ls.enable = true;
+          };
+          settings = {
+            lua-ls.config = luarc;
+          };
         };
 
         pre-commit-check = pre-commit-hooks.lib.${system}.run {
@@ -123,7 +100,10 @@
 
         devShell = pkgs.integration-nightly.overrideAttrs (oa: {
           name = "rocks.nvim devShell";
-          inherit (pre-commit-check) shellHook;
+          shellHook = ''
+            ${pre-commit-check.shellHook}
+            ln -fs ${pkgs.luarc-to-json luarc} .luarc.json
+          '';
           buildInputs = with pre-commit-hooks.packages.${system};
             [
               alejandra


### PR DESCRIPTION
This is for the nix devShell:

It generates a `.luarc.json` with all the luarocks dependencies and symlinks it.
The resulting config is the same one used by the type checker in CI.

The resulting json looks something like this:

```json
{
  "Lua": {
    "diagnostics": {
      "disable": [],
      "libraryFiles": "Disable"
    },
    "workspace": {
      "ignoreDir": [
        ".git",
        ".github",
        ".direnv",
        "result",
        "nix",
        "doc"
      ],
      "library": [
        "/nix/store/41s4jsbz8jwal2smd0qy6rfi0cnl2mbs-neovim-unwrapped-848fc8e/share/nvim/runtime/lua",
        "/nix/store/vbq303yxcq07aqxmlhk57nkgr3hzyl49-vimplugin-neodev.nvim-2024-02-16/types/nightly",
        "/nix/store/s6nhgga8p7mvkq5ksj1mrilazc92cby0-lua5.1-toml-edit-0.1.5-1/lib/lua/5.1/",
        "/nix/store/g215i1s1phrhyfrrgqw748a1l0xlz6gv-lua5.1-toml-0.3.0-0/lib/lua/5.1/",
        "/nix/store/h32a0f1vqri6rhdnw09vbcbz1i5jranq-lua5.1-fidget.nvim-1.1.0-1/share/lua/5.1",
        "/nix/store/nxwh9xyybbrgh439jva4wrxsji14j848-lua5.1-fzy-1.0-1/share/lua/5.1",
        "${3rd}/busted/library",
        "${3rd}/luassert/library"
      ]
    }
  },
  "runtime": {
    "version": "LuaJIT"
  }
}
```