### PR TITLE
fix: ignore malformed rocks

### DIFF
--- a/lua/rocks/operations.lua
+++ b/lua/rocks/operations.lua
@@ -351,9 +351,7 @@ operations.sync = function(user_rocks)
         for _, key in ipairs(to_install) do
             nio.scheduler()
             if not user_rocks[key].version then
-                local message = ("Could not parse rock: %s"):format(vim.inspect(user_rocks[key]))
-                log.error(message)
-                report_error(message)
+                -- TODO(vhyrro): Maybe add a rocks option that warns on malformed rocks?
                 goto skip_install
             end
             progress_handle:report({


### PR DESCRIPTION
This PR completely removes the error message when a malformed rock is encountered. This error is fairly redundant - it occurs when a version key could not be found, but there are many cases where you could be doing this on purpose - i.e. you are specifying a `dir` key or a `git` key.

It might make sense to add an option to issue warnings on invalid rocks if users want to be extra safe, but I'm not sure if we want that right now.
(cc @mrcjkb)