### PR TITLE
fix(installer): use `vim.o.sh` instead of `'sh'`

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -202,7 +202,7 @@ local function set_up_luarocks(install_path)
     end
 
     sc = vim.system({
-        "sh",
+        vim.o.sh,
         "configure",
         "--prefix=" .. install_path,
         "--lua-version=5.1",


### PR DESCRIPTION
On Windows, `sh` might not be available (e.g. if not installed with git).
Even if git `sh` is installed, it may not see everything that is on the `PATH` (see #166).
The default `vim.o.sh` on Windows is `cmd.exe`. On Linux and MacOS, the script should behave as before.