### PR TITLE
perf(installer): Use `--filter=blob:none` when cloning luarocks

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -177,6 +177,7 @@ local function set_up_luarocks(install_path)
     local sc = vim.system({
         "git",
         "clone",
+        "--filter=blob:none",
         "https://github.com/luarocks/luarocks.git",
         tempdir,
     }):wait()


### PR DESCRIPTION
This should reduce the amount of time it takes to clone.