### PR TITLE
revert(installer): use `vim.o.sh` instead of `'sh'`

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -185,8 +185,7 @@ local function set_up_luarocks(install_path)
     vim.notify("Configuring luarocks...")
 
     sc = vim.system({
-        vim.o.sh,
-        "configure",
+        "./configure",
         "--prefix=" .. install_path,
         "--lua-version=5.1",
         "--force-config",

--- a/installer.lua
+++ b/installer.lua
@@ -185,7 +185,8 @@ local function set_up_luarocks(install_path)
     vim.notify("Configuring luarocks...")
 
     sc = vim.system({
-        "./configure",
+        "sh"
+        "configure",
         "--prefix=" .. install_path,
         "--lua-version=5.1",
         "--force-config",


### PR DESCRIPTION
Fixes #199 

Tested on Fedora 39 with `NVIM v0.10.0-dev+2606-gc0549b9c4`