### PR TITLE
feat: lockfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - Name-based installation
   (` "nvim-neorg/neorg" ` becomes `:Rocks install neorg` instead).
 - Supports [multiple versions of the same dependency](https://github.com/luarocks/luarocks/wiki/Using-LuaRocks#multiple-versions-using-the-luarocks-package-loader).
+- Lockfile `rocks.lock` for dependencies.
 - Minimal, non-intrusive UI.
 - Async execution.
 - Extensible, with a Lua API.
@@ -468,6 +469,12 @@ You can also pin/unpin installed plugins with:
 ```vim
 :Rocks [pin|unpin] {rock}
 ```
+
+### lockfile
+
+When installing or updating, `rocks.nvim` maintains a `rocks.lock` file,
+which pins all SemVer dependency versions for each plugin.
+You can check the lockfile into SCM.
 
 ## :package: Extending `rocks.nvim`
 

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -105,6 +105,8 @@ RocksOpts                                                            *RocksOpts*
                                                       (Default: a `rocks` directory in `vim.fn.stdpath("data")`).
         {config_path?}                    (string)
                                                       Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
+        {lockfile_path?}                  (string)
+                                                      Rocks lockfile path. Defaults to `rocks.lock` in `vim.fn.stdpath("config")`.
         {luarocks_binary?}                (string)
                                                       Luarocks binary path. Defaults to the bundled installation if executable.
         {lazy?}                           (boolean)

--- a/flake.lock
+++ b/flake.lock
@@ -588,11 +588,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1720424647,
-        "narHash": "sha256-fxNxyMY8yq6IoBIrBB6mncdk9BLO0RdEZ3CMVu1LOE8=",
+        "lastModified": 1720376781,
+        "narHash": "sha256-qtvL3oS9Kv78U/u6y9DS1MaM4ynLc8jKiwY0ZlcKt7c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6edd5cc7bd8eb73d2e7c2f05b34c04a7a4d02de9",
+        "rev": "c5a88c73c67d6c1f4dcdfa1a1fe380fc92fa0406",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,13 +50,7 @@
         "x86_64-darwin"
         "aarch64-darwin"
       ];
-      perSystem = {
-        config,
-        self',
-        inputs',
-        system,
-        ...
-      }: let
+      perSystem = {system, ...}: let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -24,6 +24,9 @@ local config = {}
 --- Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
 ---@field config_path? string
 ---
+--- Rocks lockfile path. Defaults to `rocks.lock` in `vim.fn.stdpath("config")`.
+---@field lockfile_path? string
+---
 --- Luarocks binary path. Defaults to the bundled installation if executable.
 ---@field luarocks_binary? string
 ---

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -45,6 +45,8 @@ local default_config = {
     rocks_path = default_rocks_path,
     ---@type string Rocks declaration file path
     config_path = vim.fs.joinpath(vim.fn.stdpath("config") --[[@as string]], "rocks.toml"),
+    ---@type string Rocks lockfile path
+    lockfile_path = vim.fs.joinpath(vim.fn.stdpath("config") --[[@as string]], "rocks.lock"),
     ---@type string Luarocks binary path
     luarocks_binary = get_default_luarocks_binary(default_rocks_path),
     ---@type boolean Whether to query luarocks.org lazily

--- a/lua/rocks/operations/add.lua
+++ b/lua/rocks/operations/add.lua
@@ -23,6 +23,7 @@ local config = require("rocks.config.internal")
 local cache = require("rocks.cache")
 local helpers = require("rocks.operations.helpers")
 local handlers = require("rocks.operations.handlers")
+local lock = require("rocks.operations.lock")
 local parser = require("rocks.operations.parser")
 local nio = require("nio")
 local progress = require("fidget.progress")
@@ -203,6 +204,7 @@ Use 'Rocks install {rock_name}' or install rocks-git.nvim.
                 user_rocks.plugins[rock_name] = installed_rock.version
             end
             fs.write_file_await(config.config_path, "w", tostring(user_rocks))
+            lock.update_lockfile(installed_rock.name)
             cache.populate_removable_rock_cache()
             vim.schedule(function()
                 -- Re-generate help tags

--- a/lua/rocks/operations/lock.lua
+++ b/lua/rocks/operations/lock.lua
@@ -1,0 +1,87 @@
+---@mod rocks.operations.lock
+--
+-- Copyright (C) 2024 Neorocks Org.
+--
+-- License:    GPLv3
+-- Created:    7 Jul 2024
+-- Updated:    7 Jul 2024
+-- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
+-- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
+--
+---@brief [[
+--
+-- Lockfile management.
+--
+---@brief ]]
+
+local config = require("rocks.config.internal")
+local fs = require("rocks.fs")
+local nio = require("nio")
+
+local lock = {}
+
+---@param reset boolean
+local function parse_rocks_lock(reset)
+    local lockfile = reset and "" or fs.read_or_create(config.lockfile_path, "")
+    return require("toml_edit").parse(lockfile)
+end
+
+---@param rock_name? rock_name
+lock.update_lockfile = nio.create(function(rock_name)
+    local luarocks_lockfiles = vim.iter(vim.api.nvim_get_runtime_file("luarocks.lock", true))
+        :filter(function(path)
+            return not rock_name or path:find(rock_name .. "/[^%/]+/luarocks.lock$") ~= nil
+        end)
+        :totable()
+    local reset = rock_name == nil
+    local rocks_lock = parse_rocks_lock(reset)
+    for _, luarocks_lockfile in ipairs(luarocks_lockfiles) do
+        local rock_key = rock_name or luarocks_lockfile:match("/([^%/]+)/[^%/]+/luarocks.lock$")
+        if rock_key then
+            local ok, loader = pcall(loadfile, luarocks_lockfile)
+            if not ok or not loader then
+                return
+            end
+            local success, luarocks_lock_tbl = pcall(loader)
+            if not success or not luarocks_lock_tbl or not luarocks_lock_tbl.dependencies then
+                return
+            end
+            rocks_lock[rock_key] = {}
+            local has_deps = false
+            for dep, version in pairs(luarocks_lock_tbl.dependencies) do
+                local is_semver = pcall(vim.version.parse, version:match("([^-]+)") or version)
+                if is_semver and dep ~= "lua" then
+                    rocks_lock[rock_key][dep] = version
+                    has_deps = true
+                end
+            end
+            if not has_deps then
+                rocks_lock[rock_key] = nil
+            end
+        end
+    end
+    fs.write_file_await(config.lockfile_path, "w", tostring(rocks_lock))
+end, 1)
+
+---@param rock_name rock_name
+---@return string | nil luarocks_lock
+lock.create_luarocks_lock = nio.create(function(rock_name)
+    local lockfile = require("toml_edit").parse_as_tbl(fs.read_or_create(config.lockfile_path, ""))
+    local dependencies = lockfile[rock_name]
+    if not dependencies then
+        return
+    end
+    local temp_dir =
+        vim.fs.joinpath(vim.fn.stdpath("run") --[[@as string]], ("luarocks-lock-%X"):format(math.random(256 ^ 7)))
+    fs.mkdir_p(temp_dir)
+    local luarocks_lock = vim.fs.joinpath(temp_dir, "luarocks.lock")
+    local content = ([[
+return {
+    dependencies = %s,
+}
+]]):format(vim.inspect(dependencies))
+    fs.write_file_await(luarocks_lock, "w", content)
+    return luarocks_lock
+end, 1)
+
+return lock

--- a/lua/rocks/operations/prune.lua
+++ b/lua/rocks/operations/prune.lua
@@ -23,6 +23,7 @@ local config = require("rocks.config.internal")
 local cache = require("rocks.cache")
 local helpers = require("rocks.operations.helpers")
 local handlers = require("rocks.operations.handlers")
+local lock = require("rocks.operations.lock")
 local nio = require("nio")
 local progress = require("fidget.progress")
 
@@ -59,6 +60,7 @@ prune.prune = function(rock_name)
                 success = false
             end
             fs.write_file_await(config.config_path, "w", tostring(user_config))
+            lock.update_lockfile()
             local user_rocks = config.get_user_rocks()
             handlers.prune_user_rocks(user_rocks, report_progress, report_error)
             cache.populate_removable_rock_cache()

--- a/lua/rocks/operations/sync.lua
+++ b/lua/rocks/operations/sync.lua
@@ -117,7 +117,7 @@ operations.sync = function(user_rocks, on_complete)
                 if vim.startswith(user_rocks[key].version, "scm-") then
                     user_rocks[key].version = "dev"
                 end
-                local future = helpers.install(user_rocks[key])
+                local future = helpers.install(user_rocks[key], { use_lockfile = true })
                 local success = pcall(future.wait)
 
                 ct = ct + 1
@@ -162,7 +162,7 @@ operations.sync = function(user_rocks, on_complete)
                     message = is_downgrading and ("Downgrading: %s"):format(key) or ("Updating: %s"):format(key),
                 })
 
-                local future = helpers.install(user_rocks[key])
+                local future = helpers.install(user_rocks[key], { use_lockfile = true })
                 local success = pcall(future.wait)
 
                 ct = ct + 1

--- a/lua/rocks/operations/update.lua
+++ b/lua/rocks/operations/update.lua
@@ -23,6 +23,7 @@ local config = require("rocks.config.internal")
 local state = require("rocks.state")
 local cache = require("rocks.cache")
 local helpers = require("rocks.operations.helpers")
+local lock = require("rocks.operations.lock")
 local handlers = require("rocks.operations.handlers")
 local nio = require("nio")
 local progress = require("fidget.progress")
@@ -170,6 +171,7 @@ update.update = function(on_complete, opts)
                 end
             end
             fs.write_file_await(config.config_path, "w", tostring(user_rocks))
+            lock.update_lockfile()
             nio.scheduler()
             if not vim.tbl_isempty(error_handles) then
                 local message = "Update completed with errors! Run ':Rocks log' for details."

--- a/spec/operations/lock_spec.lua
+++ b/spec/operations/lock_spec.lua
@@ -1,0 +1,157 @@
+---@diagnostic disable: inject-field
+
+local tempdir = vim.fn.tempname()
+vim.system({ "rm", "-r", tempdir }):wait()
+vim.system({ "mkdir", "-p", tempdir }):wait()
+vim.g.rocks_nvim = {
+    luarocks_binary = "luarocks",
+    rocks_path = tempdir,
+    config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
+}
+
+local lock = require("rocks.operations.lock")
+local fs = require("rocks.fs")
+local config = require("rocks.config.internal")
+local helpers = require("rocks.operations.helpers")
+local state = require("rocks.state")
+local nio = require("nio")
+
+vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
+
+describe("operations.lock", function()
+    nio.tests.it("Lockfile roundtrip", function()
+        config.lockfile_path = assert(vim.fn.tempname(), "Could not create tempname")
+        local lockfile_content = [[
+[neorg]
+"pathlib.nvim" = "2.2.0-1"
+"plenary.nvim" = "0.1.4-1"
+say = "1.4.1-3"
+"nui.nvim" = "0.3.0-1"
+"lua-utils.nvim" = "1.0.2-1"
+luassert = "1.9.0-1"
+nvim-nio = "1.7.0-1"
+[neotest]
+luassert = "1.9.0-1"
+say = "1.4.1-3"
+"plenary.nvim" = "0.1.4-1"
+]]
+        local fh = assert(io.open(config.lockfile_path, "w"), "Could not open rocks.lock for writing")
+        fh:write(lockfile_content)
+        fh:close()
+        assert.same(lockfile_content, fs.read_or_create(config.lockfile_path, ""))
+        local neorg_lockfile = assert(lock.create_luarocks_lock("neorg"), "Failed to create neorg luarocks.lock")
+        vim.fs.joinpath(vim.fn.stdpath("run") --[[@as string]], ("luarocks-lock-%X"):format(math.random(256 ^ 7)))
+        assert(fs.mkdir_p(tempdir), "Failed to create tempdir " .. tempdir)
+        local neorg_rtp_path = vim.fs.joinpath(tempdir, "neorg", "1.0.0-1")
+        local neotest_rtp_path = vim.fs.joinpath(tempdir, "neotest", "1.0.0-1")
+
+        fs.mkdir_p(neorg_rtp_path)
+        local future = nio.control.future()
+        vim.system({ "mv", neorg_lockfile, vim.fs.joinpath(neorg_rtp_path, "luarocks.lock") }, nil, function()
+            future.set(true)
+        end)
+        future.wait()
+        future = nio.control.future()
+        vim.schedule(function()
+            vim.opt.runtimepath:append(neorg_rtp_path)
+            future.set(true)
+        end)
+        future.wait()
+        local neotest_lockfile = assert(lock.create_luarocks_lock("neotest"), "Failed to create neotest luarocks.lock")
+        fs.mkdir_p(neotest_rtp_path)
+        future = nio.control.future()
+        vim.system({ "mv", neotest_lockfile, vim.fs.joinpath(neotest_rtp_path, "luarocks.lock") }, nil, function()
+            future.set(true)
+        end)
+        future.wait()
+        future = nio.control.future()
+        vim.schedule(function()
+            vim.opt.runtimepath:append(neotest_rtp_path)
+            future.set(true)
+        end)
+        future.wait()
+        -- Reset lockfile path
+        config.lockfile_path = assert(vim.fn.tempname(), "Could not create tempname")
+        lock.update_lockfile()
+        nio.sleep(2000)
+        future = nio.control.future()
+        vim.schedule(function()
+            vim.opt.runtimepath:remove(neorg_rtp_path)
+            vim.opt.runtimepath:remove(neotest_rtp_path)
+            future.set(true)
+        end)
+        future.wait()
+        local roundtrip_content = fs.read_or_create(config.lockfile_path, "")
+        local result = require("toml_edit").parse_as_tbl(roundtrip_content)
+        local expected = {
+            neorg = {
+                ["nvim-nio"] = "1.7.0-1",
+                luassert = "1.9.0-1",
+                ["lua-utils.nvim"] = "1.0.2-1",
+                ["nui.nvim"] = "0.3.0-1",
+                say = "1.4.1-3",
+                ["plenary.nvim"] = "0.1.4-1",
+                ["pathlib.nvim"] = "2.2.0-1",
+            },
+            neotest = {
+                ["plenary.nvim"] = "0.1.4-1",
+                luassert = "1.9.0-1",
+                say = "1.4.1-3",
+            },
+        }
+        assert.same(expected, result)
+    end)
+    nio.tests.it("Excludes lua and dev dependencies", function()
+        local luarocks_lockfile_content = [[
+return {
+   dependencies = {
+      lua = "5.1-1",
+      luassert = "1.9.0-1",
+      ["plenary.nvim"] = "scm-1",
+      say = "1.4.1-3"
+   },
+}
+]]
+        tempdir = vim.fn.tempname()
+        local neotest_rtp_path = vim.fs.joinpath(tempdir, "neotest", "1.0.0-1")
+        fs.mkdir_p(neotest_rtp_path)
+        local luarocks_lockfile_path = vim.fs.joinpath(neotest_rtp_path, "luarocks.lock")
+        local fh = assert(io.open(luarocks_lockfile_path, "w"), "Could not open luarocks.lock for writing")
+        fh:write(luarocks_lockfile_content)
+        fh:close()
+        local future = nio.control.future()
+        vim.schedule(function()
+            vim.opt.runtimepath:append(neotest_rtp_path)
+            future.set(true)
+        end)
+        future.wait()
+        config.lockfile_path = assert(vim.fn.tempname(), "Could not create tempname")
+        lock.update_lockfile()
+        nio.sleep(2000)
+        local lockfile_content = fs.read_or_create(config.lockfile_path, "")
+        local result = require("toml_edit").parse_as_tbl(lockfile_content)
+        local expected = {
+            neotest = {
+                luassert = "1.9.0-1",
+                say = "1.4.1-3",
+            },
+        }
+        assert.same(expected, result)
+    end)
+    nio.tests.it("install installs pinned dependencies", function()
+        local lockfile_content = [[
+["oil.nvim"]
+"nvim-web-devicons" = "0.99-1"
+]]
+        config.lockfile_path = assert(vim.fn.tempname(), "Could not create tempname")
+        local fh = assert(io.open(config.lockfile_path, "w"), "Could not open rocks.lock for writing")
+        fh:write(lockfile_content)
+        fh:close()
+        helpers.install({ name = "oil.nvim", version = "2.7.0" }, { use_lockfile = true }).wait()
+        local installed_rocks = state.installed_rocks()
+        assert.same({
+            name = "nvim-web-devicons",
+            version = "0.99",
+        }, installed_rocks["nvim-web-devicons"])
+    end)
+end)

--- a/spec/operations/sync_spec.lua
+++ b/spec/operations/sync_spec.lua
@@ -5,6 +5,7 @@ vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
+    lockfile_path = vim.fs.joinpath(tempdir, "rocks.lock"),
 }
 local nio = require("nio")
 local operations = require("rocks.operations")


### PR DESCRIPTION
Closes #34.

The [documentation](https://github.com/luarocks/luarocks/wiki/Pinning-versions-with-a-lock-file#using-pinned-dependencies-in-luarocks) says luarocks will use a lockfile if there is one in the cwd.
But I haven't confirmed this yet.

This needs some vigorous testing.

### How it works

Adding/updating/removing rocks: 

- We add a `--pin` flag to the `install` command
- luarocks creates a luarocks.lock file in the rock's install tree (for all transitive dependencies of the installed rock)
- We add the path to the rtp
- We load the lockfile and use it to update our rocks-lock.toml

Syncing rocks:

- We get the locked dependencies from our rocks-lock.toml
- We use those to create a luarocks.lock in a temp directory
- We set the `cwd` to the location of the lock file for any `install` commands