### PR TITLE
refactor: replace `toml` dependency with `toml-edit` for decoding

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -31,8 +31,7 @@ jobs:
           version: ${{ env.LUAROCKS_VERSION }}
           test_interpreters: ""
           dependencies: |
-            toml-edit >= 0.1.5
-            toml
+            toml-edit >= 0.3.3
             fidget.nvim >= 1.1.0
             fzy
             nvim-nio

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,7 @@
               editorconfig-checker
             ]
             ++ (with pkgs; [
+              busted-nightly
               # For tree-sitter parsers that need sources
               # to be generated
               gcc

--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -52,7 +52,7 @@ local default_config = {
     ---@type fun():RocksToml
     get_rocks_toml = function()
         local config_file = fs.read_or_create(config.config_path, constants.DEFAULT_CONFIG)
-        local rocks_toml = require("toml").decode(config_file)
+        local rocks_toml = require("toml_edit").parse_as_tbl(config_file)
         for key, tbl in pairs(rocks_toml) do
             if key == "rocks" or key == "plugins" then
                 for name, data in pairs(tbl) do

--- a/lua/rocks/health.lua
+++ b/lua/rocks/health.lua
@@ -32,26 +32,6 @@ local warn = h.warn
 ---@field url string URL (markdown)
 ---@field info string Additional information
 
----@type LuaDependency[]
-local lua_dependencies = {
-    {
-        module = "toml",
-        optional = function()
-            return true
-        end,
-        url = "[toml.lua](https://luarocks.org/modules/LebJe/toml)",
-        info = "Required for TOML config serialization.",
-    },
-    {
-        module = "toml_edit",
-        optional = function()
-            return true
-        end,
-        url = "[toml-edit](https://luarocks.org/modules/neorg/toml-edit)",
-        info = "Required for TOML config editing.",
-    },
-}
-
 ---@class (exact) ExternalDependency
 ---@field name string Name of the dependency
 ---@field get_binaries fun():string[]Function that returns the binaries to check for
@@ -91,19 +71,6 @@ local external_dependencies = {
         info = "luarocks requires a Lua installation.",
     },
 }
-
----@param dep LuaDependency
-local function check_lua_dependency(dep)
-    if pcall(require, dep.module) then
-        ok(dep.url .. " installed.")
-        return
-    end
-    if dep.optional() then
-        warn(("%s not installed. %s %s"):format(dep.module, dep.info, dep.url))
-    else
-        error(("Lua dependency %s not found: %s"):format(dep.module, dep.url))
-    end
-end
 
 ---@param dep ExternalDependency
 ---@return boolean is_installed
@@ -165,11 +132,6 @@ local function check_config()
 end
 
 function health.check()
-    start("Checking for Lua dependencies")
-    for _, dep in ipairs(lua_dependencies) do
-        check_lua_dependency(dep)
-    end
-
     start("Checking external dependencies")
     for _, dep in ipairs(external_dependencies) do
         check_external_dependency(dep)

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -7,7 +7,7 @@
     toml-edit =
       (luaself.callPackage ({
         buildLuarocksPackage,
-        fetchgit,
+        fetchzip,
         fetchurl,
         lua,
         luaOlder,
@@ -15,33 +15,25 @@
       }:
         buildLuarocksPackage {
           pname = "toml-edit";
-          version = "0.1.5-1";
+          version = "0.3.3-1";
           knownRockspec =
             (fetchurl {
-              url = "mirror://luarocks/toml-edit-0.1.5-1.rockspec";
-              sha256 = "1xgjh8x44kn24vc29si811zq2a7pr24zqj4w07pys5k6ccnv26qz";
+              url = "mirror://luarocks/toml-edit-0.3.3-1.rockspec";
+              sha256 = "024s0x7g3i8014ay6ssax8zdsfda8n5dl354phks0cchjl7jsiqw";
             })
             .outPath;
-          src = fetchgit (removeAttrs (builtins.fromJSON ''            {
-              "url": "https://github.com/vhyrro/toml-edit.lua",
-              "rev": "34f072d8ff054b3124d9d2efc0263028d7425525",
-              "date": "2023-12-29T15:53:36+01:00",
-              "path": "/nix/store/z1gn59hz9ypk3icn3gmafaa19nzx7a1v-toml-edit.lua",
-              "sha256": "0jzzp4sd48haq1kmh2k85gkygfq39i10kvgjyqffcrv3frdihxvx",
-              "hash": "sha256-fXcYW3ZjZ+Yc9vLtCUJMA7vn5ytoClhnwAoi0jS5/0s=",
-              "fetchLFS": false,
-              "fetchSubmodules": true,
-              "deepClone": false,
-              "leaveDotGit": false
-            }
-          '') ["date" "path" "sha256"]);
+          src = fetchzip {
+            url = "https://github.com/vhyrro/toml-edit.lua/archive/v0.3.3.zip";
+            sha256 = "10nvn1snagrqkqx48r16nzbgyhcg020lprw2qgpwbyl7ycp4ppmc";
+          };
 
-          propagatedBuildInputs = [lua luarocks-build-rust-mlua];
+          disabled = luaOlder "5.1";
+          propagatedBuildInputs = [lua];
         }) {})
       .overrideAttrs (oa: {
         cargoDeps = final.rustPlatform.fetchCargoTarball {
           src = oa.src;
-          hash = "sha256-gvUqkLOa0WvAK4GcTkufr0lC2BOs2FQ2bgFpB0qa47k=";
+          hash = "sha256-Fmd69FGHqITotrXNTfuuWGI+d+i2zq9hwjQMjF+isE4=";
         };
         nativeBuildInputs = with final; [cargo rustPlatform.cargoSetupHook] ++ oa.nativeBuildInputs;
       });
@@ -117,7 +109,6 @@
       buildLuarocksPackage,
       lua,
       luarocks,
-      toml,
       toml-edit,
       fidget-nvim,
       nvim-nio,
@@ -131,7 +122,6 @@
         disabled = luaOlder "5.1";
         propagatedBuildInputs = [
           luarocks
-          toml
           toml-edit
           fidget-nvim
           nvim-nio

--- a/rocks.nvim-scm-1.rockspec
+++ b/rocks.nvim-scm-1.rockspec
@@ -8,8 +8,7 @@ version = _MODREV .. _SPECREV
 
 dependencies = {
     "lua >= 5.1",
-    "toml-edit >= 0.1.5",
-    "toml",
+    "toml-edit >= 0.3.3",
     "fidget.nvim >= 1.1.0",
     "fzy",
     "nvim-nio",
@@ -17,8 +16,7 @@ dependencies = {
 
 test_dependencies = {
     "lua >= 5.1",
-    "toml-edit >= 0.1.5",
-    "toml",
+    "toml-edit >= 0.3.3",
     "fidget.nvim >= 1.1.0",
     "fzy",
     "nvim-nio",


### PR DESCRIPTION
Fixes #228.

Blocked until toml-edit 0.3.3 has been pushed to luarocks