### PR TITLE
fix(runtime): append start plugins to rtp before calling preload hooks

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -284,7 +284,8 @@ Intended for use by modules that extend this plugin.
 
  |preload|
  By providing a module with the pattern, `rocks-<extension>.rocks.hooks.preload`,
- rocks.nvim modules can execute code before rocks.nvim loads any plugins.
+ rocks.nvim modules can execute code before rocks.nvim loads any plugins
+ (but after they have been added to the runtimepath).
 
  To be able to use this feature, a rocks.nvim extension *must* be named with a 'rocks-'
  prefix.

--- a/lua/rocks/api/hooks.lua
+++ b/lua/rocks/api/hooks.lua
@@ -11,7 +11,7 @@
 --
 -- License:    GPLv3
 -- Created:    19 Mar 2024
--- Updated:    19 Mar 2024
+-- Updated:    11 Apr 2024
 -- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
 -- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
 
@@ -46,7 +46,8 @@ end
 ---
 --- |preload|
 --- By providing a module with the pattern, `rocks-<extension>.rocks.hooks.preload`,
---- rocks.nvim modules can execute code before rocks.nvim loads any plugins.
+--- rocks.nvim modules can execute code before rocks.nvim loads any plugins
+--- (but after they have been added to the runtimepath).
 ---
 --- To be able to use this feature, a rocks.nvim extension *must* be named with a 'rocks-'
 --- prefix.

--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -1,3 +1,11 @@
+-- Copyright (C) 2024 Neorocks Org.
+--
+-- License:    GPLv3
+-- Created:    05 Jul 2023
+-- Updated:    11 Apr 2024
+-- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
+-- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
+
 if vim.g.rocks_nvim_loaded then
     return
 end
@@ -39,6 +47,7 @@ adapter.init()
 
 --- We don't want to run this async, to ensure proper initialisation order
 local user_rocks = config.get_user_rocks()
+require("rocks.runtime").rtp_append_start_plugins(user_rocks)
 require("rocks.api.hooks").run_preload_hooks(user_rocks)
 require("rocks.runtime").source_start_plugins(user_rocks)
 


### PR DESCRIPTION
Closes #237.

This fixes the loading order issue (e.g. colorschemes) for rocks-config.nvim:

1. Append start plugins to the rtp
2. Call preload hooks -> rocks-config.nvim
3. Source plugin directories

With this, I don't think rocks-config needs to worry about providing `before` or `after`  config mechanisms.