### PR TITLE
fix(operations): always force reinstalls if rocks are already installed

### DIFF
--- a/lua/rocks/operations/helpers.lua
+++ b/lua/rocks/operations/helpers.lua
@@ -61,6 +61,7 @@ helpers.install = function(rock_spec, progress_handle)
             table.insert(install_cmd, version)
         end
     end
+    table.insert(install_cmd, 2, "--force")
     luarocks.cli(install_cmd, function(sc)
         ---@cast sc vim.SystemCompleted
         if sc.code ~= 0 then


### PR DESCRIPTION
Fixes #351 

Note: This doesn't actually work with luarocks 3.11.0, see https://github.com/luarocks/luarocks/issues/1657