### PR TITLE
fix(tree-sitter): stop creating now redundant `rocks_rtp/parser` symlink

### DIFF
--- a/lua/rocks/adapter.lua
+++ b/lua/rocks/adapter.lua
@@ -29,8 +29,6 @@ local data_dir = vim.fn.stdpath("data")
 ---@cast data_dir string
 local site_link_dir = vim.fs.joinpath(data_dir, "site", "pack", "luarocks", "opt")
 
-local rocks_parser_dir = vim.fs.joinpath(config.rocks_path, "lib", "lua", "5.1", "parser")
-
 ---@type async fun(symlink_location: string, symlink_dir_name: string, dest_dir_path: string)
 local create_symlink = nio.create(function(symlink_location, symlink_dir_name, dest_dir_path)
     local symlink_dir_path = vim.fs.joinpath(symlink_location, symlink_dir_name)
@@ -55,13 +53,6 @@ local function validate_symlink_dir(symlink_dir)
     end
 end
 
---- @type async function
---- Check if the tree-sitter parser symlink is valid,
---- and remove it if it isn't
-adapter.validate_tree_sitter_parser_symlink = nio.create(function()
-    validate_symlink_dir(vim.fs.joinpath(rtp_link_dir, "parser"))
-end)
-
 --- Neovim doesn't support `:checkhealth` for luarocks plugins.
 --- To work around this, we create a symlink in the `rocks_path` that
 --- we add to the runtimepath, so that Neovim can find health files.
@@ -70,15 +61,6 @@ local function init_checkhealth_symlink()
     local _, stat = nio.uv.fs_stat(rocks_lua_dir)
     if stat then
         create_symlink(rtp_link_dir, "lua", rocks_lua_dir)
-    end
-end
-
---- If any tree-sitter parsers are installed,
--- initialise a symlink so that Neovim can find them.
-function adapter.init_tree_sitter_parser_symlink()
-    local _, stat = nio.uv.fs_stat(rocks_parser_dir)
-    if stat then
-        create_symlink(rtp_link_dir, "parser", rocks_parser_dir)
     end
 end
 
@@ -131,8 +113,6 @@ local function init_rtp_links()
         return
     end
     init_checkhealth_symlink()
-    adapter.validate_tree_sitter_parser_symlink()
-    adapter.init_tree_sitter_parser_symlink()
 end
 
 --- Initialise/validate site symlinks so that 'autoload' and 'colors', etc.

--- a/lua/rocks/operations/helpers.lua
+++ b/lua/rocks/operations/helpers.lua
@@ -86,7 +86,6 @@ helpers.install = function(rock_spec, progress_handle)
             end
 
             nio.run(function()
-                adapter.init_tree_sitter_parser_symlink()
                 adapter.init_site_symlinks()
                 if config.dynamic_rtp and not rock_spec.opt then
                     nio.scheduler()
@@ -118,7 +117,6 @@ helpers.remove = function(name, progress_handle)
         name,
     }, function(sc)
         nio.run(function()
-            adapter.validate_tree_sitter_parser_symlink()
             adapter.validate_site_symlinks()
             ---@cast sc vim.SystemCompleted
             if sc.code ~= 0 then

--- a/spec/adapter_spec.lua
+++ b/spec/adapter_spec.lua
@@ -19,19 +19,7 @@ local luarocks_path = {
 package.path = package.path .. ";" .. table.concat(luarocks_path, ";")
 
 adapter.init()
-local rtp_link_dir = vim.fs.joinpath(config.rocks_path, "rocks_rtp")
-local parser_dir = vim.fs.joinpath(rtp_link_dir, "parser")
 describe("rocks.adapter", function()
-    nio.tests.it("Sets up and removes symlinks when tree-sitter parser is installed/uninstalled", function()
-        assert.is_nil(vim.uv.fs_stat(parser_dir))
-        -- TODO: Set fixed version when stable parsers have been released
-        helpers.install({ name = "tree-sitter-toml", version = "dev" }).wait()
-        adapter.init()
-        assert.is_not_nil(vim.uv.fs_stat(parser_dir))
-        helpers.remove("tree-sitter-toml").wait()
-        adapter.init()
-        assert.is_nil(vim.uv.fs_stat(parser_dir))
-    end)
     nio.tests.it("Can run checkhealth for luarocks plugins", function()
         local mock_health = mock({
             check = function(_) end,


### PR DESCRIPTION
Fixes #354.

Existing installations may still have a `parser` symlink in the `rocks_rtp` directory (typically `~/.local/share/rocks/rocks_rtp`) after upgrading, which will need to be removed manually.

It doesn't cause any actual issues (besides duplicated captures, visible with `:Inspect`), which is why I chose not to add logic for removing it (as this adds overhead).