### PR TITLE
docs(readme): add luajit as requirement for homebrew users 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ dependencies = {
 - The `git` command line utility.
 - `wget` or `curl` (if running on a UNIX system) - required for the remote `:source` command to work.
 - `netrw` enabled in your Neovim configuration - enabled by default but some configurations manually disable the plugin.
-- A `lua 5.1` installation (for luarocks). macOS brew users can do `brew install luajit` as the `lua@5.1` brew formulae has [been disabled](https://formulae.brew.sh/formula/lua@5.1).
+- A `lua 5.1` or `luajit` installation (for luarocks).
 
 > [!IMPORTANT]
 >

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ dependencies = {
 - The `git` command line utility.
 - `wget` or `curl` (if running on a UNIX system) - required for the remote `:source` command to work.
 - `netrw` enabled in your Neovim configuration - enabled by default but some configurations manually disable the plugin.
-- A `lua 5.1` installation (for luarocks).
+- A `lua 5.1` installation (for luarocks). macOS brew users can do `brew install luajit` as the `lua@5.1` brew formulae has [been disabled](https://formulae.brew.sh/formula/lua@5.1).
 
 > [!IMPORTANT]
 >


### PR DESCRIPTION
Installing lua 5.1 using `brew install lua@5.1` results in an error due to the formula being disabled. Instead macOS brew users can do `brew install luajit`