### PR TITLE
fix(luarocks): set `LUA_PATH` and `LUA_CPATH`

### DIFF
--- a/lua/rocks/luarocks.lua
+++ b/lua/rocks/luarocks.lua
@@ -74,6 +74,8 @@ luarocks.cli = function(args, on_exit, opts)
     opts.env = vim.tbl_deep_extend("force", opts.env or {}, {
         LUAROCKS_CONFIG = config.luarocks_config,
         TREE_SITTER_LANGUAGE_VERSION = tostring(vim.treesitter.language_version),
+        LUA_PATH = package.path,
+        LUA_CPATH = package.cpath,
     })
     local luarocks_cmd = {
         config.luarocks_binary,


### PR DESCRIPTION
Fixes #373.

If these variables are set (e.g. by homebrew), the bundled luarocks install may not find its libraries.