### PR TITLE
feat(api): `RockSpecModifier` preload hooks

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -260,15 +260,41 @@ rocks.nvim API hooks                                           *rocks.api.hooks*
 Hooks that rocks.nvim modules can inject behaviour into.
 Intended for use by modules that extend this plugin.
 
+ Preload hooks                                                *rocks.hooks.preload*
 
-
- |preload|
  By providing a module with the pattern, `rocks-<extension>.rocks.hooks.preload`,
  rocks.nvim modules can execute code before rocks.nvim loads any plugins
  (but after they have been added to the runtimepath).
+ The module should return a table of type |rocks.hooks.Preload|.
 
  To be able to use this feature, a rocks.nvim extension *must* be named with a 'rocks-'
  prefix.
+
+
+rocks.hooks.RockSpecModifier                      *rocks.hooks.RockSpecModifier*
+
+    Fields: ~
+        {hook}  (fun():rock_spec_modifier)
+        {type}  ("RockSpecModifier")
+
+
+rocks.hooks.Action                                          *rocks.hooks.Action*
+
+    Fields: ~
+        {hook}  (fun(user_rocks:table<rock_name,RockSpec>))
+        {type}  ("Action")
+
+
+rocks.hooks.Preload                                        *rocks.hooks.Preload*
+
+    Type: ~
+        rocks.hooks.RockSpecModifier|rocks.hooks.Action
+
+
+rock_spec_modifier                                          *rock_spec_modifier*
+
+    Type: ~
+        fun(rock:RockSpec):RockSpec
 
 
 ==============================================================================

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -274,7 +274,7 @@ Intended for use by modules that extend this plugin.
 rocks.hooks.RockSpecModifier                      *rocks.hooks.RockSpecModifier*
 
     Fields: ~
-        {hook}  (fun():rock_spec_modifier)
+        {hook}  (rock_spec_modifier)
         {type}  ("RockSpecModifier")
 
 

--- a/lua/rocks/api/hooks.lua
+++ b/lua/rocks/api/hooks.lua
@@ -5,19 +5,42 @@
 ---Hooks that rocks.nvim modules can inject behaviour into.
 ---Intended for use by modules that extend this plugin.
 ---
+--- Preload hooks                                                *rocks.hooks.preload*
+---
+--- By providing a module with the pattern, `rocks-<extension>.rocks.hooks.preload`,
+--- rocks.nvim modules can execute code before rocks.nvim loads any plugins
+--- (but after they have been added to the runtimepath).
+--- The module should return a table of type |rocks.hooks.Preload|.
+---
+--- To be able to use this feature, a rocks.nvim extension *must* be named with a 'rocks-'
+--- prefix.
+---
 ---@brief ]]
 
 -- Copyright (C) 2024 Neorocks Org.
 --
 -- License:    GPLv3
 -- Created:    19 Mar 2024
--- Updated:    11 Apr 2024
+-- Updated:    19 Jun 2024
 -- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
 -- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
+
+---@class rocks.hooks.RockSpecModifier
+---@field hook fun():rock_spec_modifier
+---@field type 'RockSpecModifier'
+
+---@class rocks.hooks.Action
+---@field hook fun(user_rocks: table<rock_name, RockSpec>)
+---@field type 'Action'
+
+---@alias rocks.hooks.Preload rocks.hooks.RockSpecModifier | rocks.hooks.Action
+
+---@alias rock_spec_modifier fun(rock: RockSpec):RockSpec
 
 local hooks = {}
 
 local log = require("rocks.log")
+local config = require("rocks.config.internal")
 
 ---@param rock RockSpec
 ---@return string | nil
@@ -42,30 +65,32 @@ local function search_for_preload_hook(rock_name)
     end
 end
 
----@brief [[
----
---- |preload|
---- By providing a module with the pattern, `rocks-<extension>.rocks.hooks.preload`,
---- rocks.nvim modules can execute code before rocks.nvim loads any plugins
---- (but after they have been added to the runtimepath).
----
---- To be able to use this feature, a rocks.nvim extension *must* be named with a 'rocks-'
---- prefix.
----
----@brief ]]
-
 ---@package
----@param user_rocks RockSpec[]
+---@param user_rocks table<rock_name, RockSpec>
 function hooks.run_preload_hooks(user_rocks)
     log.trace("Running preload hooks")
+    ---@type fun(user_rocks: RockSpec[])[]
+    local actions = {}
     for _, rock_spec in pairs(user_rocks) do
         local rock_extension_module_name = not rock_spec.opt and get_rocks_extension_module_name(rock_spec)
-        local hook = rock_extension_module_name and search_for_preload_hook(rock_extension_module_name)
-        if hook then
+        local loader = rock_extension_module_name and search_for_preload_hook(rock_extension_module_name)
+        if loader then
             -- NOTE We want this to panic if it fails, as it could otherwise
             -- lead to harder to debug error messages.
-            hook()
+            local preload_hook = loader()
+            if type(preload_hook) == "table" and preload_hook.type then
+                ---@cast preload_hook rocks.hooks.Preload
+                if preload_hook.type == "Action" then
+                    table.insert(actions, preload_hook.hook)
+                elseif preload_hook.type == "RockSpecModifier" then
+                    config.register_rock_spec_modifier(preload_hook.hook)
+                end
+            end
         end
+    end
+    user_rocks = config.apply_rock_spec_modifiers(user_rocks)
+    for _, action in pairs(actions) do
+        action(user_rocks)
     end
 end
 

--- a/lua/rocks/api/hooks.lua
+++ b/lua/rocks/api/hooks.lua
@@ -26,7 +26,7 @@
 -- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
 
 ---@class rocks.hooks.RockSpecModifier
----@field hook fun():rock_spec_modifier
+---@field hook rock_spec_modifier
 ---@field type 'RockSpecModifier'
 
 ---@class rocks.hooks.Action

--- a/spec/hook_spec.lua
+++ b/spec/hook_spec.lua
@@ -1,0 +1,73 @@
+local tempdir = vim.fn.tempname()
+local rtp_dir = vim.fs.joinpath(tempdir, "rtp")
+vim.system({ "rm", "-r", tempdir }):wait()
+vim.system({ "mkdir", "-p", tempdir }):wait()
+vim.g.rocks_nvim = {
+    luarocks_binary = "luarocks",
+    rocks_path = tempdir,
+    config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
+}
+
+describe("hooks", function()
+    it("modifiers and actions", function()
+        local config = require("rocks.config.internal")
+        -- Test sync without any rocks
+        local config_content = [[
+[plugins]
+rocks-modifier.nvim = "1.0.0"
+rocks-action.nvim = "1.0.0"
+]]
+        local fh = assert(io.open(config.config_path, "w"), "Could not open rocks.toml for writing")
+        fh:write(config_content)
+        fh:close()
+        local lua_dir = vim.fs.joinpath(rtp_dir, "lua")
+        local modifier_hook_dir = vim.fs.joinpath(lua_dir, "rocks-modifier", "rocks", "hooks")
+        local action_hook_dir = vim.fs.joinpath(lua_dir, "rocks-action", "rocks", "hooks")
+        vim.system({ "mkdir", "-p", modifier_hook_dir }):wait()
+        vim.system({ "mkdir", "-p", action_hook_dir }):wait()
+        local modifier_hook_content = [[
+return {
+    type = "RockSpecModifier",
+    hook = function(rock)
+        rock.opt = true
+        return rock
+    end,
+}
+]]
+        fh = assert(
+            io.open(vim.fs.joinpath(modifier_hook_dir, "preload.lua"), "w"),
+            "Could not open modifier hook file for writing"
+        )
+        fh:write(modifier_hook_content)
+        fh:close()
+        local action_hook_content = [[
+return {
+    type = "Action",
+    hook = function()
+      vim.g.action_hook_sourced = true
+    end,
+}
+]]
+        fh = assert(
+            io.open(vim.fs.joinpath(action_hook_dir, "preload.lua"), "w"),
+            "Could not open action hook file for writing"
+        )
+        fh:write(action_hook_content)
+        fh:close()
+        vim.opt.runtimepath:append(rtp_dir)
+        local user_rocks = config.get_user_rocks()
+        assert.is_nil(vim.g.action_hook_sourced)
+        vim.iter(user_rocks):each(function(_, rock)
+            assert.is_nil(rock.opt)
+        end)
+        require("rocks.api.hooks").run_preload_hooks(user_rocks)
+        vim.iter(user_rocks):each(function(_, rock)
+            assert.True(rock.opt)
+        end)
+        assert.True(vim.g.action_hook_sourced)
+        user_rocks = config.get_user_rocks()
+        vim.iter(user_rocks):each(function(_, rock)
+            assert.True(rock.opt)
+        end)
+    end)
+end)


### PR DESCRIPTION
This refines the preload hook API to support different types of hooks.

For now, the following are supported:

- `RockSpecModifier`s, which allow extensions to modify the hooks that rocks.nvim sees.
  - rocks-lazy.nvim will be able to use this to let rocks.nvim know that a plugin is `opt`, without users having to set the `opt` field.
  - This could potentially also be useful for the rocks-nix.nvim module I'm planning.
- `Action`s, which is what we have already implemented in rocks-config.nvim, only that it can now take the (potentially modified) `user_rocks: RockSpec[]` as a parameter, so that rocks-config.nvim doesn't have to read it from the rocks.toml again.

The modifier does not do anything with the `MutRocksTomlRef` (the one we use to write to rocks.toml on install, update, ...). I think it's good that it doesn't.