### PR TITLE
fix(runtime): make sure dependencies' rtp directories can be used

### DIFF
--- a/lua/rocks/adapter.lua
+++ b/lua/rocks/adapter.lua
@@ -103,6 +103,13 @@ adapter.init_site_symlinks = nio.create(function()
     local state = require("rocks.state")
     for _, rock in pairs(state.installed_rocks()) do
         init_site_symlink(rock)
+        -- Since we're invoking this in the :h load-plugins phase of the startup sequence,
+        -- this packadd! call won't result in any scripts being sourced.
+        nio.scheduler()
+        local ok, err = pcall(vim.cmd.packadd, { rock.name, bang = true })
+        if not ok then
+            log.error(err)
+        end
     end
 end)
 


### PR DESCRIPTION
This fixes a bug (parially introduced in #355)

I was mistaken in my assumption that Neovim makes  `site/pack/*/opt` packages' rtp directories  available without calling `packadd!`.
Apparently it only does that for colorschemes.

Since rocks.nvim initialises as a `plugin` script, during the `:h load-plugins` phase of Neovim's initialisation, we can safely call `packadd!` (with a bang) for all installed rocks, without causing Neovim to source any plugin scripts.
This makes all rtp directories (e.g. `autoload`) available, so luarocks plugins can have vimscript plugins like `repeat.vim` as dependencies.