### PR TITLE
docs(vimdoc): log level

### DIFF
--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -49,7 +49,7 @@ rocks.nvim commands                                             *rocks.commands*
 rocks.nvim configuration                                          *rocks.config*
 
 
- rocks.nvim configuration options
+ You can set rocks.nvim configuration options via `vim.g.rocks_nvim`.
 
 >
  ---@type RocksOpts
@@ -57,6 +57,8 @@ rocks.nvim configuration                                          *rocks.config*
 <
 
 
+                                                              *vim.g.rocks_nvim*
+                                                                  *g:rocks_nvim*
 RocksOpts                                                            *RocksOpts*
 
     Fields: ~
@@ -318,6 +320,17 @@ log.warn()                                                            *log.warn*
 
 
 log.error()                                                          *log.error*
+
+
+log.set_level()                                                  *log.set_level*
+
+    See: ~
+        |vim.log.levels|
+
+    Usage: ~
+>lua
+        log.set_level(vim.log.levels.DEBUG)
+<
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
 
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -2,7 +2,7 @@
 ---
 ---@brief [[
 ---
---- rocks.nvim configuration options
+--- You can set rocks.nvim configuration options via `vim.g.rocks_nvim`.
 ---
 --->
 --- ---@type RocksOpts
@@ -13,6 +13,8 @@
 
 local config = {}
 
+---@tag vim.g.rocks_nvim
+---@tag g:rocks_nvim
 ---@class RocksOpts
 ---@field rocks_path? string Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
 ---@field config_path? string Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.

--- a/lua/rocks/log.lua
+++ b/lua/rocks/log.lua
@@ -94,7 +94,7 @@ end
 ---Set the log level
 ---@param level (string|integer) The log level
 ---@see vim.log.levels
----@package
+---@usage `log.set_level(vim.log.levels.DEBUG)`
 function log.set_level(level)
     if type(level) == "string" then
         log.level = assert(log_levels[string.upper(level)], string.format("rocks.nvim: Invalid log level: %q", level))


### PR DESCRIPTION
I first wanted to document vim.g.rocks_nvim._log_level but it is ignored after startup so it didn't seem like a good idea after all.
I've instead exposed log.set_level. The description of the function is ignored for some reason :s 

I've added doc tags for `vim.g.rocks_nvim`