### PR TITLE
feat(log): trace luarocks_config path

### DIFF
--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -24,6 +24,7 @@ log.trace("loading rocks.adapter")
 local adapter = require("rocks.adapter")
 log.trace("loading rocks config")
 local config = require("rocks.config.internal")
+log.debug("Using luarocks config " .. config.luarocks_config)
 
 -- Initialize the luarocks loader
 if config.enable_luarocks_loader then


### PR DESCRIPTION
To help debug/diagnose if config is correctly set. It can be deceiving in case vim.g.rocks_nvim gets changed later.

Which is why at first I thought of passing the luarocks config via the command line instead of the environment but luarocks still doesn't support it: https://github.com/luarocks/luarocks/issues/1086

This looks like a good compromise.