### PR TITLE
feat: support extending the default luarocks config

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
           cat rocks/rocks.log
           echo "vim.cmd.colorscheme('sweetie')" >> .github/resources/init-integration.lua
           echo "vim.cmd.e('success')" >> .github/resources/init-integration.lua
-          nvim -u .github/resources/init-integration.lua -c 'set noswapfile' +wq || true
+          nvim -u .github/resources/init-integration.lua -c 'set noswapfile' +wq
           if [ ! -f success ]; then
             echo "Integration test failed!"
             exit 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: nightly
+          version: stable
       - name: Install rocks.nvim
         run: |
           mkdir rocks
@@ -54,7 +54,7 @@ jobs:
           cat rocks/rocks.log
           echo "vim.cmd.colorscheme('sweetie')" >> .github/resources/init-integration.lua
           echo "vim.cmd.e('success')" >> .github/resources/init-integration.lua
-          nvim -u .github/resources/init-integration.lua -c +wq
+          nvim -u .github/resources/init-integration.lua -c 'set noswapfile' +wq || true
           if [ ! -f success ]; then
             echo "Integration test failed!"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-result
+result*
 https___*
 .pre-commit-config.yaml
 .direnv

--- a/README.md
+++ b/README.md
@@ -342,8 +342,11 @@ Examples:
 
 ### Updating rocks
 
-Running the `:Rocks update` command will attempt to update every available rock
-if it is not pinned.
+- Running the `:Rocks update` command will update every available rock
+  that is not pinned.
+
+- `:Rocks install {rock}` (without a version) will update `{rock}`
+  to the latest version.
 
 ### Syncing rocks
 

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -98,31 +98,29 @@ RocksOpts                                                            *RocksOpts*
 
     Fields: ~
         {rocks_path?}                     (string)
-                                                           Local path in your file system to install rocks
-                                                           (Default: a `rocks` directory in `vim.fn.stdpath("data")`).
+                                                      Local path in your file system to install rocks
+                                                      (Default: a `rocks` directory in `vim.fn.stdpath("data")`).
         {config_path?}                    (string)
-                                                           Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
+                                                      Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
         {luarocks_binary?}                (string)
-                                                           Luarocks binary path (Default: `{rocks_path}/bin/luarocks`).
+                                                      Luarocks binary path (Default: `{rocks_path}/bin/luarocks`).
         {lazy?}                           (boolean)
-                                                           Whether to query luarocks.org lazily (Default: `false`).
-                                                           Setting this to `true` may improve startup time,
-                                                           but features like auto-completion will lag initially.
+                                                      Whether to query luarocks.org lazily (Default: `false`).
+                                                      Setting this to `true` may improve startup time,
+                                                      but features like auto-completion will lag initially.
         {dynamic_rtp?}                    (boolean)
-                                                           Whether to automatically add freshly installed plugins to the 'runtimepath'.
-                                                           (Default: `true` for the best default experience).
+                                                      Whether to automatically add freshly installed plugins to the 'runtimepath'.
+                                                      (Default: `true` for the best default experience).
         {generate_help_pages?}            (boolean)
-                                                           Whether to re-generate plugins help pages after installation/upgrade. (Default: `true`).
+                                                      Whether to re-generate plugins help pages after installation/upgrade. (Default: `true`).
         {reinstall_dev_rocks_on_update?}  (boolean)
-                                                           Whether to reinstall 'dev' rocks on update
-                                                           (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
+                                                      Whether to reinstall 'dev' rocks on update
+                                                      (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
         {enable_luarocks_loader?}         (boolean)
-                                                           Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
-        {luarocks_config?}                (string|table)
-                                                           Path to the luarocks config file or table of extra luarocks config options.
-                                                           If a table or not set, rocks.nvim will create a default luarocks config in `rocks_path`
-                                                           and merge it with this table.
-                                                           Warning: this is a file path, You should include the settings in the default luarocks-config.lua before overriding this.
+                                                      Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
+        {luarocks_config?}                (table)
+                                                      Extra luarocks config options.
+                                                      rocks.nvim will create a default luarocks config in `rocks_path` and merge it with this table (if set).
 
 
 ==============================================================================

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -68,11 +68,14 @@ rocks.nvim commands                                             *rocks-commands*
                                        - pin={true|false}
                                          Rocks that have been installed with 'pim=true'
                                          will be ignored by ':Rocks update'.
+                                     Use 'Rocks! install ...' to skip prompts
  prune {rock}                        Uninstall {rock} and its stale dependencies,
                                      and remove it from rocks.toml.
  sync                                Synchronize installed rocks with rocks.toml.
                                      It may take more than one sync to prune all rocks that can be pruned.
  update                              Search for updated rocks and install them.
+                                     Use 'Rocks! update` to skip prompts
+                                     with breaking changes.
  edit                                Edit the rocks.toml file.
  pin {rock}                          Pin {rock} to the installed version.
                                      Pinned rocks are ignored by ':Rocks update'.

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -97,15 +97,32 @@ rocks.nvim configuration                                          *rocks-config*
 RocksOpts                                                            *RocksOpts*
 
     Fields: ~
-        {rocks_path?}                     (string)   Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
-        {config_path?}                    (string)   Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
-        {luarocks_binary?}                (string)   Luarocks binary path. Defaults to `{rocks_path}/bin/luarocks`.
-        {lazy?}                           (boolean)  Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
-        {dynamic_rtp?}                    (boolean)  Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
-        {generate_help_pages?}            (boolean)  Whether to re-generate plugins help pages after installation/upgrade. Defaults to `true`.
-        {reinstall_dev_rocks_on_update?}  (boolean)  Whether to reinstall 'dev' rocks on update (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
-        {enable_luarocks_loader?}         (boolean)  Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
-        {luarocks_config?}                (string)   Path to the luarocks config. If not set, rocks.nvim will create one in `rocks_path`. Warning: You should include the settings in the default luarocks-config.lua before overriding this.
+        {rocks_path?}                     (string)
+                                                           Local path in your file system to install rocks
+                                                           (Default: a `rocks` directory in `vim.fn.stdpath("data")`).
+        {config_path?}                    (string)
+                                                           Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
+        {luarocks_binary?}                (string)
+                                                           Luarocks binary path (Default: `{rocks_path}/bin/luarocks`).
+        {lazy?}                           (boolean)
+                                                           Whether to query luarocks.org lazily (Default: `false`).
+                                                           Setting this to `true` may improve startup time,
+                                                           but features like auto-completion will lag initially.
+        {dynamic_rtp?}                    (boolean)
+                                                           Whether to automatically add freshly installed plugins to the 'runtimepath'.
+                                                           (Default: `true` for the best default experience).
+        {generate_help_pages?}            (boolean)
+                                                           Whether to re-generate plugins help pages after installation/upgrade. (Default: `true`).
+        {reinstall_dev_rocks_on_update?}  (boolean)
+                                                           Whether to reinstall 'dev' rocks on update
+                                                           (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
+        {enable_luarocks_loader?}         (boolean)
+                                                           Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
+        {luarocks_config?}                (string|table)
+                                                           Path to the luarocks config file or table of extra luarocks config options.
+                                                           If a table or not set, rocks.nvim will create a default luarocks config in `rocks_path`
+                                                           and merge it with this table.
+                                                           Warning: this is a file path, You should include the settings in the default luarocks-config.lua before overriding this.
 
 
 ==============================================================================

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,6 @@
             inherit nvim;
             plugins = with pkgs.lua51Packages; [
               toml-edit
-              toml
               fidget-nvim
               fzy
               nvim-nio

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -140,7 +140,7 @@ local rocks_command_tbl = {
                 return
             end
             require("rocks.operations").add(args, nil, {
-                auto_search_dev = opts.bang,
+                skip_prompts = opts.bang,
             })
         end,
         complete = function(query)

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -124,7 +124,7 @@ local rocks_command_tbl = {
     update = {
         impl = function(_, opts)
             require("rocks.operations").update(nil, {
-                skip_prompt = opts.bang,
+                skip_prompts = opts.bang,
             })
         end,
     },

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -16,12 +16,13 @@
 ---                                       - pin={true|false}
 ---                                         Rocks that have been installed with 'pim=true'
 ---                                         will be ignored by ':Rocks update'.
+---                                     Use 'Rocks! install ...' to skip prompts
 --- prune {rock}                        Uninstall {rock} and its stale dependencies,
 ---                                     and remove it from rocks.toml.
 --- sync                                Synchronize installed rocks with rocks.toml.
 ---                                     It may take more than one sync to prune all rocks that can be pruned.
 --- update                              Search for updated rocks and install them.
----                                     Use 'Rocks! update` to skip prompts to install updates
+---                                     Use 'Rocks! update` to skip prompts
 ---                                     with breaking changes.
 --- edit                                Edit the rocks.toml file.
 --- pin {rock}                          Pin {rock} to the installed version.
@@ -133,12 +134,14 @@ local rocks_command_tbl = {
         end,
     },
     install = {
-        impl = function(args)
+        impl = function(args, opts)
             if #args == 0 then
                 vim.notify("Rocks install: Called without required package argument.", vim.log.levels.ERROR)
                 return
             end
-            require("rocks.operations").add(args)
+            require("rocks.operations").add(args, nil, {
+                auto_search_dev = opts.bang,
+            })
         end,
         complete = function(query)
             local name, version_query = query:match("([^%s]+)%s(.+)$")

--- a/lua/rocks/commands.lua
+++ b/lua/rocks/commands.lua
@@ -21,6 +21,8 @@
 --- sync                                Synchronize installed rocks with rocks.toml.
 ---                                     It may take more than one sync to prune all rocks that can be pruned.
 --- update                              Search for updated rocks and install them.
+---                                     Use 'Rocks! update` to skip prompts to install updates
+---                                     with breaking changes.
 --- edit                                Edit the rocks.toml file.
 --- pin {rock}                          Pin {rock} to the installed version.
 ---                                     Pinned rocks are ignored by ':Rocks update'.
@@ -119,8 +121,10 @@ end
 ---@type { [string]: RocksCmd }
 local rocks_command_tbl = {
     update = {
-        impl = function(_)
-            require("rocks.operations").update()
+        impl = function(_, opts)
+            require("rocks.operations").update(nil, {
+                skip_prompt = opts.bang,
+            })
         end,
     },
     sync = {

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -46,11 +46,9 @@ local config = {}
 --- Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
 ---@field enable_luarocks_loader? boolean
 ---
---- Path to the luarocks config file or table of extra luarocks config options.
---- If a table or not set, rocks.nvim will create a default luarocks config in `rocks_path`
---- and merge it with this table.
---- Warning: this is a file path, You should include the settings in the default luarocks-config.lua before overriding this.
----@field luarocks_config? string | table
+--- Extra luarocks config options.
+--- rocks.nvim will create a default luarocks config in `rocks_path` and merge it with this table (if set).
+---@field luarocks_config? table
 
 ---@type RocksOpts | fun():RocksOpts
 vim.g.rocks_nvim = vim.g.rocks_nvim

--- a/lua/rocks/config/init.lua
+++ b/lua/rocks/config/init.lua
@@ -16,15 +16,41 @@ local config = {}
 ---@tag vim.g.rocks_nvim
 ---@tag g:rocks_nvim
 ---@class RocksOpts
----@field rocks_path? string Local path in your filesystem to install rocks. Defaults to a `rocks` directory in `vim.fn.stdpath("data")`.
----@field config_path? string Rocks declaration file path. Defaults to `rocks.toml` in `vim.fn.stdpath("config")`.
----@field luarocks_binary? string Luarocks binary path. Defaults to `{rocks_path}/bin/luarocks`.
----@field lazy? boolean Whether to query luarocks.org lazily. Defaults to `false`. Setting this to `true` may improve startup time, but features like auto-completion will lag initially.
----@field dynamic_rtp? boolean Whether to automatically add freshly installed plugins to the 'runtimepath'. Defaults to `true` for the best default experience.
----@field generate_help_pages? boolean Whether to re-generate plugins help pages after installation/upgrade. Defaults to `true`.
----@field reinstall_dev_rocks_on_update? boolean Whether to reinstall 'dev' rocks on update (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
----@field enable_luarocks_loader? boolean Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
----@field luarocks_config? string Path to the luarocks config. If not set, rocks.nvim will create one in `rocks_path`. Warning: You should include the settings in the default luarocks-config.lua before overriding this.
+---
+--- Local path in your file system to install rocks
+--- (Default: a `rocks` directory in `vim.fn.stdpath("data")`).
+---@field rocks_path? string
+---
+--- Rocks declaration file path (Default: `rocks.toml`) in `vim.fn.stdpath("config")`.
+---@field config_path? string
+---
+--- Luarocks binary path (Default: `{rocks_path}/bin/luarocks`).
+---@field luarocks_binary? string
+---
+--- Whether to query luarocks.org lazily (Default: `false`).
+--- Setting this to `true` may improve startup time,
+--- but features like auto-completion will lag initially.
+---@field lazy? boolean
+---
+--- Whether to automatically add freshly installed plugins to the 'runtimepath'.
+--- (Default: `true` for the best default experience).
+---@field dynamic_rtp? boolean
+---
+--- Whether to re-generate plugins help pages after installation/upgrade. (Default: `true`).
+---@field generate_help_pages? boolean
+---
+--- Whether to reinstall 'dev' rocks on update
+--- (Default: `true`, as rocks.nvim cannot determine if 'dev' rocks are up to date).
+---@field reinstall_dev_rocks_on_update? boolean
+---
+--- Whether to use the luarocks loader to support multiple dependencies (Default: `true`).
+---@field enable_luarocks_loader? boolean
+---
+--- Path to the luarocks config file or table of extra luarocks config options.
+--- If a table or not set, rocks.nvim will create a default luarocks config in `rocks_path`
+--- and merge it with this table.
+--- Warning: this is a file path, You should include the settings in the default luarocks-config.lua before overriding this.
+---@field luarocks_config? string | table
 
 ---@type RocksOpts | fun():RocksOpts
 vim.g.rocks_nvim = vim.g.rocks_nvim

--- a/lua/rocks/loader.lua
+++ b/lua/rocks/loader.lua
@@ -2,59 +2,46 @@ local loader = {}
 
 local log = require("rocks.log")
 local config = require("rocks.config.internal")
-local nio = require("nio")
 
 ---@return string | nil
 local function get_luarocks_lua_dir_from_luarocks()
-    local future = nio.control.future()
-    local ok = pcall(
-        vim.system,
-        { config.luarocks_binary, "--lua-version=5.1", "which", "luarocks.loader" },
-        nil,
-        function(sc)
-            future.set(sc)
-        end
-    )
+    ---@type boolean, vim.SystemObj
+    local ok, so = pcall(vim.system, { config.luarocks_binary, "--lua-version=5.1", "which", "luarocks.loader" }, nil)
     if not ok then
         log.error(("Could not invoke luarocks at %s"):format(config.luarocks_binary))
         return
     end
     ---@type vim.SystemCompleted
-    local sc = future.wait()
+    local sc = so:wait()
     local result = sc.stdout and sc.stdout:match(vim.fs.joinpath("(%S+)", "5.1", "luarocks", "loader.lua"))
     return result
 end
 
----@type async fun():boolean
-loader.enable = nio.create(function()
+---@return boolean success
+function loader.enable()
     local luarocks_config_path = config.luarocks_config_path()
+    log.trace("Enabling luarocks loader")
     local luarocks_lua_dir = config.luarocks_binary == config.default_luarocks_binary
             and vim.fs.joinpath(config.rocks_path, "share", "lua")
         or get_luarocks_lua_dir_from_luarocks()
-    local future = nio.control.future()
-    vim.schedule(function()
-        log.trace("Enabling luarocks loader")
-        if luarocks_lua_dir then
-            package.path = package.path
-                .. ";"
-                .. table.concat({
-                    vim.fs.joinpath(luarocks_lua_dir, "5.1", "?.lua"),
-                    vim.fs.joinpath(luarocks_lua_dir, "5.1", "init.lua"),
-                }, ";")
-            vim.env.LUAROCKS_CONFIG = luarocks_config_path
-            local ok, err = pcall(require, "luarocks.loader")
-            if ok then
-                future.set(true)
-                return
-            end
-            log.error(err or "Unknown error initializing luarocks loader")
-            vim.notify("Failed to initialize luarocks loader: " .. err, vim.log.levels.WARN, {
-                title = "rocks.nvim",
-            })
+    if luarocks_lua_dir then
+        package.path = package.path
+            .. ";"
+            .. table.concat({
+                vim.fs.joinpath(luarocks_lua_dir, "5.1", "?.lua"),
+                vim.fs.joinpath(luarocks_lua_dir, "5.1", "init.lua"),
+            }, ";")
+        vim.env.LUAROCKS_CONFIG = luarocks_config_path
+        local ok, err = pcall(require, "luarocks.loader")
+        if ok then
+            return true
         end
-        future.set(false)
-    end)
-    return future.wait()
-end)
+        log.error(err or "Unknown error initializing luarocks loader")
+        vim.notify("Failed to initialize luarocks loader: " .. err, vim.log.levels.WARN, {
+            title = "rocks.nvim",
+        })
+    end
+    return false
+end
 
 return loader

--- a/lua/rocks/loader.lua
+++ b/lua/rocks/loader.lua
@@ -2,43 +2,59 @@ local loader = {}
 
 local log = require("rocks.log")
 local config = require("rocks.config.internal")
+local nio = require("nio")
 
 ---@return string | nil
 local function get_luarocks_lua_dir_from_luarocks()
-    local ok, so = pcall(vim.system, { config.luarocks_binary, "--lua-version=5.1", "which", "luarocks.loader" })
+    local future = nio.control.future()
+    local ok = pcall(
+        vim.system,
+        { config.luarocks_binary, "--lua-version=5.1", "which", "luarocks.loader" },
+        nil,
+        function(sc)
+            future.set(sc)
+        end
+    )
     if not ok then
         log.error(("Could not invoke luarocks at %s"):format(config.luarocks_binary))
         return
     end
-    local sc = so:wait()
+    ---@type vim.SystemCompleted
+    local sc = future.wait()
     local result = sc.stdout and sc.stdout:match(vim.fs.joinpath("(%S+)", "5.1", "luarocks", "loader.lua"))
     return result
 end
 
----@return boolean
-function loader.enable()
+---@type async fun():boolean
+loader.enable = nio.create(function()
     log.trace("Enabling luarocks loader")
+    local luarocks_config_path = config.luarocks_config_path()
     local luarocks_lua_dir = config.luarocks_binary == config.default_luarocks_binary
             and vim.fs.joinpath(config.rocks_path, "share", "lua")
         or get_luarocks_lua_dir_from_luarocks()
-    if luarocks_lua_dir then
-        package.path = package.path
-            .. ";"
-            .. table.concat({
-                vim.fs.joinpath(luarocks_lua_dir, "5.1", "?.lua"),
-                vim.fs.joinpath(luarocks_lua_dir, "5.1", "init.lua"),
-            }, ";")
-        vim.env.LUAROCKS_CONFIG = config.luarocks_config
-        local ok, err = pcall(require, "luarocks.loader")
-        if ok then
-            return true
+    local future = nio.control.future()
+    vim.schedule(function()
+        if luarocks_lua_dir then
+            package.path = package.path
+                .. ";"
+                .. table.concat({
+                    vim.fs.joinpath(luarocks_lua_dir, "5.1", "?.lua"),
+                    vim.fs.joinpath(luarocks_lua_dir, "5.1", "init.lua"),
+                }, ";")
+            vim.env.LUAROCKS_CONFIG = luarocks_config_path
+            local ok, err = pcall(require, "luarocks.loader")
+            if ok then
+                future.set(true)
+                return
+            end
+            log.error(err or "Unknown error initializing luarocks loader")
+            vim.notify("Failed to initialize luarocks loader: " .. err, vim.log.levels.WARN, {
+                title = "rocks.nvim",
+            })
         end
-        log.error(err or "Unknown error initializing luarocks loader")
-        vim.notify("Failed to initialize luarocks loader: " .. err, vim.log.levels.WARN, {
-            title = "rocks.nvim",
-        })
-    end
-    return false
-end
+        future.set(false)
+    end)
+    return future.wait()
+end)
 
 return loader

--- a/lua/rocks/loader.lua
+++ b/lua/rocks/loader.lua
@@ -27,13 +27,13 @@ end
 
 ---@type async fun():boolean
 loader.enable = nio.create(function()
-    log.trace("Enabling luarocks loader")
     local luarocks_config_path = config.luarocks_config_path()
     local luarocks_lua_dir = config.luarocks_binary == config.default_luarocks_binary
             and vim.fs.joinpath(config.rocks_path, "share", "lua")
         or get_luarocks_lua_dir_from_luarocks()
     local future = nio.control.future()
     vim.schedule(function()
+        log.trace("Enabling luarocks loader")
         if luarocks_lua_dir then
             package.path = package.path
                 .. ";"

--- a/lua/rocks/luarocks.lua
+++ b/lua/rocks/luarocks.lua
@@ -49,7 +49,7 @@ end
 ---   asynchronously. Receives SystemCompleted object, see return of SystemObj:wait().
 ---@param opts? LuarocksCliOpts
 ---@see vim.system
-luarocks.cli = function(args, on_exit, opts)
+luarocks.cli = nio.create(function(args, on_exit, opts)
     opts = opts or {}
     ---@cast opts LuarocksCliOpts
     opts.synchronized = opts.synchronized ~= nil and opts.synchronized or false
@@ -72,7 +72,7 @@ luarocks.cli = function(args, on_exit, opts)
         semaphore.acquire()
     end
     opts.env = vim.tbl_deep_extend("force", opts.env or {}, {
-        LUAROCKS_CONFIG = config.luarocks_config,
+        LUAROCKS_CONFIG = config.luarocks_config_path(),
         TREE_SITTER_LANGUAGE_VERSION = tostring(vim.treesitter.language_version),
         LUA_PATH = ('"%s"'):format(package.path),
         LUA_CPATH = ('"%s"'):format(package.cpath),
@@ -97,7 +97,7 @@ luarocks.cli = function(args, on_exit, opts)
         }
         on_exit_wrapped(sc)
     end
-end
+end, 3)
 
 ---@class LuarocksSearchOpts
 ---@field dev? boolean Include dev manifest? Default: false

--- a/lua/rocks/operations/helpers.lua
+++ b/lua/rocks/operations/helpers.lua
@@ -30,7 +30,7 @@ local helpers = {}
 ---@param rock_spec RockSpec
 ---@param progress_handle? ProgressHandle
 ---@return nio.control.Future
-helpers.install = function(rock_spec, progress_handle)
+helpers.install = nio.create(function(rock_spec, progress_handle)
     cache.invalidate_removable_rocks()
     local name = rock_spec.name:lower()
     local version = rock_spec.version
@@ -103,7 +103,7 @@ helpers.install = function(rock_spec, progress_handle)
         servers = servers,
     })
     return future
-end
+end, 2)
 
 ---Removes a rock
 ---@param name string

--- a/lua/rocks/operations/init.lua
+++ b/lua/rocks/operations/init.lua
@@ -566,6 +566,13 @@ Use 'Rocks install {rock_name}' or install rocks-git.nvim.
             end
             local install_spec = parse_result.spec
             local version = install_spec.version
+            local breaking_change = not version and helpers.get_breaking_change(rock_name)
+            if breaking_change and not helpers.prompt_for_breaking_intall(breaking_change) then
+                progress_handle:report({
+                    title = "Installation aborted",
+                })
+                progress_handle:cancel()
+            end
             nio.scheduler()
             progress_handle:report({
                 message = version and ("%s -> %s"):format(rock_name, version) or rock_name,

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -51,10 +51,9 @@ state.installed_rocks = nio.create(function()
     return rocks
 end)
 
----@type async fun(): {[string]: OutdatedRock}
+---@type async fun(): table<rock_name, OutdatedRock>
 state.outdated_rocks = nio.create(function()
-    local rocks = vim.empty_dict()
-    ---@cast rocks {[string]: Rock}
+    local rocks = vim.empty_dict() --[[ @as table<rock_name, OutdatedRock> ]]
 
     local future = nio.control.future()
 

--- a/lua/rocks/state.lua
+++ b/lua/rocks/state.lua
@@ -23,7 +23,7 @@ local config = require("rocks.config.internal")
 local log = require("rocks.log")
 local nio = require("nio")
 
----@type async fun(): {[string]: Rock}
+---@type async fun(): table<rock_name, Rock>
 state.installed_rocks = nio.create(function()
     local rocks = vim.empty_dict()
     ---@cast rocks {[string]: Rock}

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -13,7 +13,6 @@
           with ps; [
             final.lua51Packages.luarocks-rock
             toml-edit
-            toml
             fidget-nvim
             fzy
             nvim-nio

--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -28,7 +28,7 @@ log.debug("Using luarocks config " .. config.luarocks_config)
 
 -- Initialize the luarocks loader
 if config.enable_luarocks_loader then
-    require("rocks.loader").enable()
+    nio.run(require("rocks.loader").enable)
 end
 
 -- Set up the Rocks user command

--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -24,11 +24,12 @@ log.trace("loading rocks.adapter")
 local adapter = require("rocks.adapter")
 log.trace("loading rocks config")
 local config = require("rocks.config.internal")
-log.debug("Using luarocks config " .. config.luarocks_config)
 
 -- Initialize the luarocks loader
 if config.enable_luarocks_loader then
-    nio.run(require("rocks.loader").enable)
+    nio.run(function()
+        require("rocks.loader").enable()
+    end)
 end
 
 -- Set up the Rocks user command

--- a/plugin/rocks.lua
+++ b/plugin/rocks.lua
@@ -27,9 +27,7 @@ local config = require("rocks.config.internal")
 
 -- Initialize the luarocks loader
 if config.enable_luarocks_loader then
-    nio.run(function()
-        require("rocks.loader").enable()
-    end)
+    require("rocks.loader").enable()
 end
 
 -- Set up the Rocks user command

--- a/spec/loader_spec.lua
+++ b/spec/loader_spec.lua
@@ -1,10 +1,12 @@
+vim.env.PLENARY_TEST_TIMEOUT = 60000
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
 }
 local loader = require("rocks.loader")
+local nio = require("nio")
 
 describe("rocks.loader", function()
-    it("Can enable luarocks.loader", function()
+    nio.tests.it("Can enable luarocks.loader", function()
         assert.True(loader.enable())
     end)
 end)

--- a/spec/loader_spec.lua
+++ b/spec/loader_spec.lua
@@ -3,10 +3,9 @@ vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
 }
 local loader = require("rocks.loader")
-local nio = require("nio")
 
 describe("rocks.loader", function()
-    nio.tests.it("Can enable luarocks.loader", function()
+    it("Can enable luarocks.loader", function()
         assert.True(loader.enable())
     end)
 end)

--- a/spec/luarocks_config_spec.lua
+++ b/spec/luarocks_config_spec.lua
@@ -1,0 +1,34 @@
+local nio = require("nio")
+
+vim.env.PLENARY_TEST_TIMEOUT = 60000
+
+describe("luarocks config", function()
+    nio.tests.it("extra luarocks_config", function()
+        local tempdir = vim.fn.tempname()
+
+        local external_deps_dirs = {
+            "/some/path",
+        }
+
+        vim.g.rocks_nvim = {
+            luarocks_binary = "luarocks",
+            rocks_path = tempdir,
+            luarocks_config = {
+                external_deps_dirs = external_deps_dirs,
+            },
+        }
+
+        local config = require("rocks.config.internal")
+        nio.sleep(2000)
+        assert.is_not_nil(vim.uv.fs_stat(config.luarocks_config))
+        local luarocks_config = {}
+        loadfile(config.luarocks_config, "t", luarocks_config)()
+        assert.same({
+            lua_version = "5.1",
+            external_deps_dirs = external_deps_dirs,
+            rocks_trees = {
+                { name = "rocks.nvim", root = tempdir },
+            },
+        }, luarocks_config)
+    end)
+end)

--- a/spec/luarocks_config_spec.lua
+++ b/spec/luarocks_config_spec.lua
@@ -19,10 +19,10 @@ describe("luarocks config", function()
         }
 
         local config = require("rocks.config.internal")
-        nio.sleep(2000)
-        assert.is_not_nil(vim.uv.fs_stat(config.luarocks_config))
+        local luarocks_config_path = config.luarocks_config_path()
+        assert.is_not_nil(vim.uv.fs_stat(luarocks_config_path))
         local luarocks_config = {}
-        loadfile(config.luarocks_config, "t", luarocks_config)()
+        loadfile(luarocks_config_path, "t", luarocks_config)()
         assert.same({
             lua_version = "5.1",
             external_deps_dirs = external_deps_dirs,

--- a/spec/operations/helpers_spec.lua
+++ b/spec/operations/helpers_spec.lua
@@ -37,4 +37,15 @@ describe("operations.helpers", function()
             print("GIT2_DIR not set. Skipping install_args test case")
         end
     end)
+    it("Detect breaking changes", function()
+        local result = helpers.get_breaking_changes({
+            foo = { name = "foo", version = "7.0.0", target_version = "8.0.0" },
+            bar = { name = "bar", version = "7.0.0", target_version = "7.1.0" },
+            baz = { name = "baz", version = "7.0.0", target_version = "7.1.1" },
+        })
+        assert.is_not_nil(result.foo)
+        assert.is_nil(result.bar)
+        assert.is_nil(result.baz)
+        assert.same("foo 7.0.0 -> 8.0.0", tostring(result.foo))
+    end)
 end)

--- a/spec/operations/install_update_spec.lua
+++ b/spec/operations/install_update_spec.lua
@@ -30,7 +30,9 @@ describe("install/update", function()
         future = nio.control.future()
         operations.update(function()
             future.set(true)
-        end)
+        end, {
+            skip_prompts = true,
+        })
         future.wait()
         installed_rocks = state.installed_rocks()
         local updated_version = vim.version.parse(installed_rocks.neorg.version)


### PR DESCRIPTION
Stacked on #442 

This adds a solution for #443 by making it easier to defend the default luarocks config.

You can add extra directories to search for binaries via

```lua
vim.g.rocks_nvim = {
  -- ...
  ---@type string | table file path or config table to extend the default with
  luarocks_config = {
    external_deps_dirs = { "/some/path" },
  },
}
```

See https://github.com/luarocks/luarocks/wiki/Config-file-format for details.