### PR TITLE
docs(readme): update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@
 
 ## :star2: Features
 
+- Automatic dependency and build script management.
+- True [semantic versioning](https://semver.org/)!
 - `Cargo`-like `rocks.toml` file for declaring all your plugins.
 - Name-based installation
   (` "nvim-neorg/neorg" ` becomes `:Rocks install neorg` instead).
-- Automatic dependency and build script management.
 - Supports [multiple versions of the same dependency](https://github.com/luarocks/luarocks/wiki/Using-LuaRocks#multiple-versions-using-the-luarocks-package-loader).
-- True semver versioning!
 - Minimal, non-intrusive UI.
 - Async execution.
 - Extensible, with a Lua API.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     for lazy-loading.
   - [`rocks-treesitter.nvim`](https://github.com/nvim-neorocks/rocks-treesitter.nvim)
     for automatic tree-sitter parser management.
-  - And more...
+  - And [more...](https://github.com/topics/rocks-nvim)
 - Command completions for plugins and versions on luarocks.org.
 - Binary rocks pulled from [rocks-binaries](https://nvim-neorocks.github.io/rocks-binaries/)
   so you don't have to compile them.
@@ -82,7 +82,7 @@ Consider the following example using lazy.nvim[^2]:
 This setup illustrates several pain points in the status quo:
 
 - Manual dependency management:
-  Users are often required to manually specify and manage dependencies.
+  Users are required to specify and manage dependencies.
 - Breaking changes:
   Updates to a plugin's dependencies can lead to breaking changes for users.
 - Platform-specific instructions:
@@ -479,6 +479,8 @@ Following are some examples:
   Adds an API for developing and testing luarocks plugins locally.
 - [`rocks-treesitter.nvim`](https://github.com/nvim-neorocks/rocks-treesitter.nvim)
   Automatic highlighting and installation of tree-sitter parsers.
+- And [more...](https://github.com/topics/rocks-nvim)
+
 
 To extend `rocks.nvim`, simply install a module with `:Rocks install`,
 and you're good to go!

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ and you're good to go!
 The `:Rocks log` command opens a log file for the current session,
 which contains the `luarocks` stderr output, among other logs.
 
-## :link: Related projects
+## :link: projects related to neovim and luarocks
 
 - [luarocks-tag-release](https://github.com/nvim-neorocks/luarocks-tag-release):
   A GitHub action that automates publishing to luarocks.org
@@ -499,6 +499,16 @@ which contains the `luarocks` stderr output, among other logs.
   to luarocks.org
 - [luarocks.nvim](https://github.com/vhyrro/luarocks.nvim):
   Adds basic support for installing lua rocks to [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+
+## :link: Other neovim plugin managers
+
+- [lazy.nvim](https://github.com/folke/lazy.nvim): started luarocks support in
+  version [11.X](https://lazy.folke.io/news#11x)
+- [mini.deps](https://github.com/echasnovski/mini.deps)
+- [paq-nvim](https://github.com/savq/paq-nvim)
+- [pckr](https://github.com/lewis6991/pckr.nvim)
+- [vim-plug](https://github.com/junegunn/vim-plug)
 
 ## :book: License
 


### PR DESCRIPTION

see commit messages but to sum up:
- moved down ``Cargo-like rocks.toml file for declaring all your plugins` since I find this a weak feature, less powerful for sure than what was coming next aka "automatic dependency management"
- Added a section to mention the competition

I dont like that we mention twice the ecosystem about all the extensions but not sure how to do better so I left it untouched.
I do think that section should appear in `:h rocks.nvim` (currently is the barebone `A luarocks plugin manager for Neovim.` xD) because users are bound to want to install plugins from git so at least rocks-git.nvim should appear in help IMO.



