### PR TITLE
fix: external sync actions not running

### DIFF
--- a/lua/rocks/operations/sync.lua
+++ b/lua/rocks/operations/sync.lua
@@ -132,7 +132,7 @@ operations.sync = function(user_rocks, on_complete)
             end
 
             -- Sync actions handled by external modules that have registered handlers
-            for _, callback in ipairs(sync_status.external_actions) do
+            for _, callback in pairs(sync_status.external_actions) do
                 ct = ct + 1
                 callback(report_progress, report_error)
             end


### PR DESCRIPTION
This bug was introduced by the refactor in commit 704940f43c600f95a5d4a5177b918af849b3a150, which changed external_actions from a list to a key-value table. However, when iterating through external_actions, we still use ipairs which results in no values.

This caused rocks-git to not run sync actions on any of its rocks, so e.g. adding `fzf-lua = { git = "ibhagwan/fzf-lua" }` to your rocks.toml then running `:Rocks sync` would not actually install fzf-lua.

> [!NOTE]
> On my machine, rocks-git properly installs its rocks after a fresh bootstrap of rocks.nvim and an initial `:Rocks sync`, but I'm not sure why it works on the first run. After that, rocks-git doesn't run its sync callback due to the bug this PR fixes.