### PR TITLE
feat: trigger `RocksInstallPost` user event after install/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ You can also pin/unpin installed plugins with:
 :Rocks [pin|unpin] {rock}
 ```
 
+## :calendar: User events
+
+For `:h User` events that rocks.nvim will trigger, see `:h rocks.user-event`.
+
 ## :package: Extending `rocks.nvim`
 
 This plugin provides a Lua API for extensibility.

--- a/doc/rocks.txt
+++ b/doc/rocks.txt
@@ -12,6 +12,7 @@ rocks.nvim ··································�
  ·································································· |rocks-toml|
 rocks.nvim commands ··········································· |rocks-commands|
 rocks.nvim configuration ········································ |rocks-config|
+rocks.nvim |User| |event|s ·································· |rocks.user-event|
 Lua API for rocks.nvim extensions ·································· |rocks-api|
 rocks.nvim API hooks ········································· |rocks-api-hooks|
 rocks.nvim logging API ············································· |rocks-log|
@@ -129,6 +130,34 @@ RocksOpts                                                            *RocksOpts*
         {luarocks_config?}                (table)
                                                       Extra luarocks config options.
                                                       rocks.nvim will create a default luarocks config in `rocks_path` and merge it with this table (if set).
+
+
+==============================================================================
+rocks.nvim |User| |event|s                                    *rocks.user-event*
+
+rocks.user-events.data.RocksInstallPost*rocks.user-events.data.RocksInstallPost*
+    The following |User| |event|s are available:
+
+    RocksInstallPost			Invoked after installing or updating a rock
+                             The `data` is of type
+                             |rocks.user-events.data.RocksInstallPost|.
+
+
+    To create an autocommand for an event:
+    >lua
+            vim.api.nvim_create_autocmd("User", {
+              pattern = "RocksInstallPost",
+              callback = function(ev)
+                 ---@type rocks.user-events.data.RocksInstallPost
+                 local data = ev.data
+                 -- ...
+              end,
+            })
+    <
+
+    Fields: ~
+        {spec}       (RockSpec)
+        {installed}  (Rock)
 
 
 ==============================================================================

--- a/lua/rocks/meta.lua
+++ b/lua/rocks/meta.lua
@@ -1,0 +1,37 @@
+-- Copyright (C) 2024 Neorocks Org.
+--
+-- License:    GPLv3
+-- Created:    03 Aug 2024
+-- Updated:    03 Aug 2024
+-- Homepage:   https://github.com/nvim-neorocks/rocks.nvim
+-- Maintainers: NTBBloodbath <bloodbathalchemist@protonmail.com>, Vhyrro <vhyrro@gmail.com>, mrcjkb <marc@jakobi.dev>
+
+---@mod rocks.user-event rocks.nvim |User| |event|s
+---
+---@brief [[
+---The following |User| |event|s are available:
+---
+---RocksInstallPost			Invoked after installing or updating a rock
+---                         The `data` is of type
+---                         |rocks.user-events.data.RocksInstallPost|.
+---
+---
+---To create an autocommand for an event:
+--->lua
+---        vim.api.nvim_create_autocmd("User", {
+---          pattern = "RocksInstallPost",
+---          callback = function(ev)
+---             ---@type rocks.user-events.data.RocksInstallPost
+---             local data = ev.data
+---             -- ...
+---          end,
+---        })
+---<
+
+---@class rocks.user-events.data.RocksInstallPost
+---@field spec RockSpec
+---@field installed Rock
+
+error("can't require a meta module")
+local meta = {}
+return meta

--- a/lua/rocks/operations/helpers.lua
+++ b/lua/rocks/operations/helpers.lua
@@ -104,6 +104,17 @@ helpers.install = nio.create(function(rock_spec, progress_handle)
                 -- We also exclude `-<specrev>` from the version match.
                 version = sc.stdout:match(name:gsub("%p", "%%%1") .. "%s+([^-%s]+)"),
             }
+            vim.schedule(function()
+                vim.api.nvim_exec_autocmds("User", {
+                    pattern = "RocksInstallPost",
+                    modeline = false,
+                    ---@type rocks.user-events.data.RocksInstallPost
+                    data = {
+                        spec = rock_spec,
+                        installed = installed_rock,
+                    },
+                })
+            end)
             message = ("Installed: %s -> %s"):format(installed_rock.name, installed_rock.version)
             log.info(message)
             if progress_handle then

--- a/nix/test-overlay.nix
+++ b/nix/test-overlay.nix
@@ -39,7 +39,7 @@
     ];
     text = ''
       mkdir -p doc
-      lemmy-help lua/rocks/{init,commands,config/init,api/{init,hooks},log}.lua > doc/rocks.txt
+      lemmy-help lua/rocks/{init,commands,config/init,meta,api/{init,hooks},log}.lua > doc/rocks.txt
     '';
   };
 in {


### PR DESCRIPTION
See also: #489

This would allow users of plugins that require an impure autoload function to be invoked to do so.
For example:

```lua
vim.api.nvim_create_autocmd("User", {
   pattern = "RocksInstallPost",
   callback = function(ev)
      if ev.data.installed.name == "firenvim" then
        vim.cmd.call("firenvim#install(0)")
      end
  end,
})
```