### PR TITLE
fix(windows): rocks.toml getting wiped on save

### DIFF
--- a/lua/rocks/fs.lua
+++ b/lua/rocks/fs.lua
@@ -48,10 +48,7 @@ function fs.write_file(location, mode, contents, callback)
     -- mode for the group and others
     uv.fs_open(location, mode, tonumber("644", 8), function(err, file)
         if file and not err then
-            local file_pipe = uv.new_pipe(false)
-            ---@cast file_pipe uv_pipe_t
-            uv.pipe_open(file_pipe, file)
-            uv.write(file_pipe, contents, function(write_err)
+            uv.fs_write(file, contents, function(write_err)
                 if write_err then
                     local msg = ("Error writing %s: %s"):format(location, err)
                     log.error(msg)


### PR DESCRIPTION
On Windows, `rocks.toml` was getting erased every time rocks tried to write to it.

It seems to have been caused by using pipes (perhaps because the behaviour on Linux is different to that of Windows).

This PR removes the pipe and uses `uv.fs_write(file, ...)` instead.

Resolves #516