### PR TITLE
fix: stop luarocks server list from being overwritten

### DIFF
--- a/lua/rocks/config/internal.lua
+++ b/lua/rocks/config/internal.lua
@@ -94,14 +94,16 @@ local default_config = {
     ---@return server_url[]
     get_servers = function()
         local luarocks_opts = config.get_rocks_toml().luarocks
+        -- WARNING: Return a copy of the constant table so it can't be modified by the caller
         return luarocks_opts and type(luarocks_opts.servers) == "table" and luarocks_opts.servers
-            or constants.DEFAULT_ROCKS_SERVERS
+            or vim.deepcopy(constants.DEFAULT_ROCKS_SERVERS)
     end,
     ---@return server_url[]
     get_dev_servers = function()
         local luarocks_opts = config.get_rocks_toml().luarocks
+        -- WARNING: Return a copy of the constant table so it can't be modified by the caller
         return luarocks_opts and type(luarocks_opts.dev_servers) == "table" and luarocks_opts.dev_servers
-            or constants.DEFAULT_DEV_SERVERS
+            or vim.deepcopy(constants.DEFAULT_DEV_SERVERS)
     end,
     ---@return server_url[]
     get_all_servers = function()


### PR DESCRIPTION
The constants `DEFAULT_ROCKS_SERVERS` and `DEFAULT_DEV_SERVERS` are tables and the `get_servers`/`get_dev_servers` can return these values meaning that the exact table instance will be returned, not a copy. This means that if the returned table instance is modified, the constants will also be modified. The `get_all_servers` function uses `vim.list_extend` which will modify the table of the first argument and so the `DEFAULT_ROCKS_SERVERS` list will continue to grow each time this function is called appending the dev servers each time. 

*May want to consider returning a copy of the constant tables OR just note to never modify the returned table values*

For some reason, this was actually causing an issue when trying to install some rocks because it would actually prioritize the luarocks manifest over the rocks-binaries server (even though it's supposed to prioritize in the reverse order of the table). Maybe the server list passed to the luarocks cli is too long and it defaults to using luarocks? Not sure, but I didn't spend any time to investigate why appending additional dev server strings to the server list would cause the rocks-binaries server to get skipped. Either way, this change fixed it for me and now the rocks-binaries server is being prioritized when doing `tree-sitter-...` package installs.