### PR TITLE
fix: make sure config_path option for installs updates correct config

### DIFF
--- a/lua/rocks/operations/helpers/init.lua
+++ b/lua/rocks/operations/helpers/init.lua
@@ -45,7 +45,7 @@ function helpers.parse_rocks_toml(config_path)
             return multi_mut_rocks_toml_wrapper.new({ { config = base_rocks_toml, path = config.config_path } })
         end
 
-        -- For non-base configs, add it to the list of imports in the base config
+        -- For non-base configs, add it to the list of imports in the base config and write async
         if base_rocks_toml.import then
             local i = 0
             local import_path
@@ -57,18 +57,12 @@ function helpers.parse_rocks_toml(config_path)
         else
             base_rocks_toml.import = { config_path }
         end
+        fs.write_file(config.config_path, "w", tostring(base_rocks_toml))
 
-        -- For non-base configs, return a combined config with the imported config having preference over the base.
-        -- Since we modified the base also, it will also need to be written, hence, we return it to allow the
-        -- caller to write the config when all other modifications are done/successful.
         return multi_mut_rocks_toml_wrapper.new({
             {
                 config = require("toml_edit").parse(fs.read_or_create(absolute_config_path, "")),
                 path = absolute_config_path,
-            },
-            {
-                config = base_rocks_toml,
-                path = config.config_path,
             },
         })
     end

--- a/lua/rocks/operations/helpers/multi_mut_rocks_toml_wrapper.lua
+++ b/lua/rocks/operations/helpers/multi_mut_rocks_toml_wrapper.lua
@@ -1,4 +1,3 @@
-local config = require("rocks.config.internal")
 local fs = require("rocks.fs")
 
 ---@class MutRocksTomlRefWithPath
@@ -46,19 +45,14 @@ end
 ---@param key string|integer
 ---@param value any
 MultiMutRocksTomlWrapper.__newindex = function(self, key, value)
-    local insert_index = 1
-    for i, tbl in ipairs(self.configs) do
-        -- Insert into base config by default
-        if tbl.path == config.config_path then
-            insert_index = i
-        end
+    for _, tbl in ipairs(self.configs) do
         if tbl.config[key] ~= nil then
             tbl.config[key] = value
             return
         end
     end
-    -- If key not found in any table, add it to the first table
-    self.configs[insert_index].config[key] = value
+    -- If key not found in any table, add it to the last table which should the base config
+    self.configs[#self.configs].config[key] = value
 end
 
 --- Run a function against the config tables

--- a/spec/operations/helpers_spec.lua
+++ b/spec/operations/helpers_spec.lua
@@ -100,6 +100,7 @@ version = "2.0.0"
 pin = true
 ]]
 
+        local _, _ = os.remove(vim.fs.joinpath(tempdir, "local-rocks.toml"))
         local fh = assert(io.open(config.config_path, "w"), "Could not open rocks.toml for writing")
         fh:write(config_content)
         fh:close()
@@ -142,30 +143,40 @@ myrock = "1.0.0"
 myrock = "1.0.0"
 ]]
 
+        local _, _ = os.remove(vim.fs.joinpath(tempdir, "local-rocks.toml"))
         local fh = assert(io.open(config.config_path, "w"), "Could not open rocks.toml for writing")
         fh:write(config_content)
         fh:close()
 
-        local _, _ = os.remove(vim.fs.joinpath(tempdir, "local-rocks.toml"))
         local rocks_toml = helpers.parse_rocks_toml("local-rocks.toml")
-        assert.same("local-rocks.toml", rocks_toml.import[1])
+        assert.same(nil, rocks_toml.rocks)
     end)
-    it("Parse rocks toml passing new import path, append to imports", function()
+    it("Parse rocks toml passing existing import path", function()
         local config_content = [[
-import = ["other-rocks.toml"]
-
 [rocks]
 myrock = "1.0.0"
 ]]
+        local config_content2 = [[
+[plugins."myplugin"]
+version = "2.0.0"
+pin = true
+]]
 
+        local _, _ = os.remove(vim.fs.joinpath(tempdir, "local-rocks.toml"))
         local fh = assert(io.open(config.config_path, "w"), "Could not open rocks.toml for writing")
         fh:write(config_content)
         fh:close()
+        fh = assert(
+            io.open(vim.fs.joinpath(tempdir, "local-rocks.toml"), "w"),
+            "Could not open local rocks.toml for writing"
+        )
+        fh:write(config_content2)
+        fh:close()
 
-        local _, _ = os.remove(vim.fs.joinpath(tempdir, "local-rocks.toml"))
         local rocks_toml = helpers.parse_rocks_toml("local-rocks.toml")
-        assert.same("other-rocks.toml", rocks_toml.import[1])
-        assert.same("local-rocks.toml", rocks_toml.import[2])
+        assert.same(nil, rocks_toml.rocks)
+        assert.same("2.0.0", rocks_toml.plugins.myplugin.version)
+        assert.same(true, rocks_toml.plugins.myplugin.pin)
     end)
 end)
 
@@ -288,7 +299,7 @@ describe("operations.helpers.multi_mut_rocks_toml_wrapper", function()
         -- Table1 modified since first
         ---@diagnostic disable-next-line: inject-field
         m.z = "new_z_value"
-        assert.same("new_z_value", table1.z)
-        assert.same(nil, table2.z)
+        assert.same("new_z_value", table2.z)
+        assert.same(nil, table1.z)
     end)
 end)


### PR DESCRIPTION
Fixes an issue with the config_path option on installs (NOTE: this only affected the new config_path feature added last PR and not anything else). This was meant to be committed as part of the last PR but I had stashed these changes temporarily while testing a slightly different implementation and then forgot to re-apply the stashed changes afterwards (I apologize for this).

The original intention was that when you provided a config_path to the `parse_rocks_toml` function, it would add the import to the base config and then provide you a wrapper object which wrapped both the base config and the newly created import config so that you could write both at once when done updating. The issue with this is that the goal of the config_path option is so that you could make changes ONLY to the specified config file but since I was providing a wrapped object, it meant that despite the imported config having preference, it could end up preferring the base config for writing if the nested table paths didn't exist in the import config (hence defeating the purpose of this feature). I realized this and changed it locally to asynchronously write the base config when the imports have been updated and only return the rocks_toml for the specified config_path so that all modifications would be guaranteed to be only done on the config_path but this was not committed unfortunately.