### PR TITLE
docs(readme): make bootstrap snippet work well with lua-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ one may use the bootstrapping script. Place the following script into your `init
 ```lua
 do
     -- Specifies where to install/use rocks.nvim
-    local install_location = vim.fs.joinpath(vim.fn.stdpath("data"), "rocks")
+    local install_location = vim.fs.joinpath(vim.fn.stdpath("data") --[[@as string]], "rocks")
 
     -- Set up configuration options related to rocks.nvim (recommended to leave as default)
     local rocks_config = {
@@ -253,22 +253,17 @@ end
 
 -- If rocks.nvim is not installed then install it!
 if not pcall(require, "rocks") then
-    local rocks_location = vim.fs.joinpath(vim.fn.stdpath("cache"), "rocks.nvim")
+    local rocks_location = vim.fs.joinpath(vim.fn.stdpath("cache") --[[@as string]], "rocks.nvim")
 
     if not vim.uv.fs_stat(rocks_location) then
         -- Pull down rocks.nvim
-        vim.fn.system({
-            "git",
-            "clone",
-            "--filter=blob:none",
-            "https://github.com/nvim-neorocks/rocks.nvim",
-            rocks_location,
-        })
+        local url = "https://github.com/nvim-neorocks/rocks.nvim"
+        vim.fn.system({ "git", "clone", "--filter=blob:none", url, rocks_location })
+        -- Make sure the clone was successfull
+        assert(vim.v.shell_error == 0, "rocks.nvim installation failed. Try exiting and re-entering Neovim!")
     end
 
     -- If the clone was successful then source the bootstrapping script
-    assert(vim.v.shell_error == 0, "rocks.nvim installation failed. Try exiting and re-entering Neovim!")
-
     vim.cmd.source(vim.fs.joinpath(rocks_location, "bootstrap.lua"))
 
     vim.fn.delete(rocks_location, "rf")


### PR DESCRIPTION
Hi,
this PR tries to:
- make the bootstrapping snippet work a bit nicer with lua-language-server. lua lsp will complain about the use of `vim.fn.stdpath` in `vim.fs.joinpath` since it can return `string[]` and will throw a warning. The fix is telling it to treat the `stdpath` call as a string.
- make the bootstrapping snippet less intimidating by reducing is sice in LOC
- remove redundant `vim.fs.normalize` call (`vim.fs.joinpath` already does that`)
- move the `vim.v.shell_error` check in the same branch as a "sanity check". It is nitpicking but, as is it right now, this can be trigger by _any_ `vim.fn.system` or `:!` gone wrong in the user configuration and moving it to the same branch as the `vim.fn.system` call that clones the repo this can make life much saner to user. 