### PR TITLE
test: tag internet tests with #online

### DIFF
--- a/.busted
+++ b/.busted
@@ -7,6 +7,10 @@ return {
     default = {
         verbose = true,
     },
+    offline = {
+       -- pattern = "spec/*_spec.lua"
+       exclude_tags = {"online"},
+    },
     tests = {
         verbose = true,
     },

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ format:
 check:
 	luacheck lua/rocks plugin/ installer.lua
 
+test-offline:
+	NVIM_APPNAME=rocks-nvim-test busted -t online spec
+
 docgen:
 	mkdir -p doc
 	vimcats lua/rocks/{init,commands,config/init,meta,api/{init,hooks},log}.lua > doc/rocks.txt

--- a/spec/operations/helpers_spec.lua
+++ b/spec/operations/helpers_spec.lua
@@ -9,7 +9,7 @@ vim.g.rocks_nvim = {
 }
 local nio = require("nio")
 vim.env.PLENARY_TEST_TIMEOUT = 60000
-describe("operations.helpers", function()
+describe("operations.helpers #online", function()
     local helpers = require("rocks.operations.helpers")
     local config = require("rocks.config.internal")
     local state = require("rocks.state")

--- a/spec/operations/install_update_spec.lua
+++ b/spec/operations/install_update_spec.lua
@@ -8,7 +8,7 @@ vim.g.rocks_nvim = {
 }
 local nio = require("nio")
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("install/update", function()
+describe("install/update #online", function()
     local operations = require("rocks.operations")
     local state = require("rocks.state")
     nio.tests.it("install and update rocks", function()

--- a/spec/operations/pin_commands_spec.lua
+++ b/spec/operations/pin_commands_spec.lua
@@ -19,7 +19,7 @@ local function parse_config()
 end
 
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("Rocks pin/unpin", function()
+describe("Rocks pin/unpin #online", function()
     nio.tests.it("pin/unpin plugin with only version", function()
         local rocks_toml = parse_config()
         rocks_toml.plugins = {}

--- a/spec/operations/pin_spec.lua
+++ b/spec/operations/pin_spec.lua
@@ -8,7 +8,7 @@ vim.g.rocks_nvim = {
 }
 local nio = require("nio")
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("install/pin/update", function()
+describe("install/pin/update #online", function()
     local operations = require("rocks.operations")
     local state = require("rocks.state")
     nio.tests.it("update skips pinned install", function()

--- a/spec/operations/sync_spec.lua
+++ b/spec/operations/sync_spec.lua
@@ -12,7 +12,7 @@ local helpers = require("rocks.operations.helpers")
 local state = require("rocks.state")
 local config = require("rocks.config.internal")
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("operations", function()
+describe("#online operations", function()
     vim.system({ "mkdir", "-p", config.rocks_path }):wait()
     nio.tests.it("sync", function()
         -- Test sync without any rocks


### PR DESCRIPTION
to allow to run  offline tests via `busted --exclude-tags=online` see https://github.com/nvim-neorocks/rocks.nvim/issues/631 

busted provides several filter but none that

currently fails with:
```
NVIM_APPNAME=rocks-nvim-test busted --tags=online spec/
✱Error executing luv callback:
...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
...ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/logger.lua:51: E5560: Vimscript function must not be called in a lua loop callback
stack traceback:
	[C]: in function 'require'
	lua/rocks/adapter.lua:164: in function 'init_site_symlinks_async'
	lua/rocks/adapter.lua:207: in function 'synchronise_site_symlinks'
	lua/rocks/adapter.lua:199: in function 'ensure_site_links'
	lua/rocks/adapter.lua:213: in function 'func'
	...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:169: in function <...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:168>
stack traceback:
	[C]: in function 'error'
	...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:100: in function 'close_task'
	...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:122: in function 'cb'
	...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:183: in function <...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:182>
	[C]: in function 'wait'
	...-unwrapped-0.10.4/share/nvim/runtime/lua/vim/_system.lua:99: in function 'wait'
	spec/config_spec.lua:4: in main chunk
	[C]: in function 'xpcall'
	...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:178: in function 'safe'
	...0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/block.lua:146: in function 'execute'
	...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/init.lua:7: in function 'executor'
	...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314: in function <...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314>
	[C]: in function 'xpcall'
	...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:178: in function 'safe'
	...f0z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314: in function 'execute'
	...8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/execute.lua:58: in function 'execute'
	...z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/runner.lua:210: in function <...z8-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/runner.lua:11>
	...d-2.2.0-1/busted-2.2.0-1-rocks/busted/2.2.0-1/bin/busted:3: in function 'fn'
	...clgmlib9alkyyzz9nm376193icy-lua5.1-nlua-0.2.0-1/bin/nlua:79: in main chunk●●●●●●●
Recursive import detected: /tmp/nix-shell.LGRGYS/rocks-nvim-test.teto/RnDIIW/5/rocks.tom
```
I have a hunch the logger is calling a forbidden vim function ?