### PR TITLE
feat: provide rocks-nvim as a vim plugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -146,9 +146,9 @@
           inherit devShell;
         };
 
-        packages = rec {
-          default = rocks-nvim;
-          inherit (pkgs.luajitPackages) rocks-nvim;
+        packages = {
+          default = pkgs.vimPlugins.rocks-nvim;
+          inherit (pkgs.vimPlugins) rocks-nvim;
           inherit
             (pkgs)
             neovim-with-rocks

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -143,6 +143,8 @@ in {
     // {
       rocks-nvim = final.neovimUtils.buildNeovimPlugin {
         luaAttr = luajitPackages.rocks-nvim;
+
+        passthru.initLua = prev.vimPlugins.rocks-nvim.passthru.initLua;
       };
     };
 


### PR DESCRIPTION
I wanted to install the plugin directly via `self.inputs.rocks-nvim.packages.${pkgs.system}.rocks-nvim` but noticed this was not possible as the attribute is the lua package.
As I am not used to haskell-parts, I first thought it was not available, seems like vimPlugins and lua sets are modified via overlays instead.
The composition of overlays can be tricky, I for instance have several customizations and would like the possibility to override selectively the plugins as well  via for instance `rocks-nvim = thisFlake.rocks-nvim-nightly`.

To be clear it's not meant to be merged as is especially as it changes the value for the default package) but rather to discuss how to expose those.
