### PR TITLE
feat(log): include milliseconds in timestamp

### DIFF
--- a/lua/rocks/log.lua
+++ b/lua/rocks/log.lua
@@ -119,8 +119,12 @@ for level, levelnr in pairs(vim.log.levels) do
         end
         local info = debug.getinfo(2, "Sl")
         local fileinfo = string.format("%s:%s", info.short_src, info.currentline)
+        local _, millis = vim.uv.gettimeofday()
         local parts = {
-            table.concat({ level, "|", os.date(log_date_format), "|", fileinfo, "|" }, " "),
+            table.concat(
+                { level, "|", os.date(log_date_format) .. "." .. tostring(millis):sub(1, 3), "|", fileinfo, "|" },
+                " "
+            ),
         }
         for i = 1, argc do
             local arg = select(i, ...)


### PR DESCRIPTION
to help troubleshoot perf issues

Before:
===
TRACE | 2025-03-13 19:10:31 | /home/teto/rocks.nvim/lua/rocks/loader.lua:23 | Enabling luarocks loader TRACE | 2025-03-13 19:10:32 | /home/teto/rocks.nvim/lua/rocks/commands.lua:281 | Creating commands TRACE | 2025-03-13 19:10:32 | /home/teto/rocks.nvim/plugin/rocks.lua:39 | Appending luarocks binary directory to the system path TRACE | 2025-03-13 19:10:32 | /home/teto/rocks.nvim/lua/rocks/api/hooks.lua:72 | Running preload hooks DEBUG | 2025-03-13 19:10:32 | /home/teto/rocks.nvim/lua/rocks/adapter.lua:42 | Symlink directory lua exists already. TRACE | 2025-03-13 19:10:32 | /home/teto/rocks.nvim/lua/rocks/runtime.lua:72 | Sourcing start plugins ===

After:
====
TRACE | 2025-03-13 19:04:08.941 | /home/teto/rocks.nvim/lua/rocks/loader.lua:23 | Enabling luarocks loader TRACE | 2025-03-13 19:04:09.239 | /home/teto/rocks.nvim/lua/rocks/commands.lua:281 | Creating commands TRACE | 2025-03-13 19:04:09.239 | /home/teto/rocks.nvim/plugin/rocks.lua:39 | Appending luarocks binary directory to the system path TRACE | 2025-03-13 19:04:09.255 | /home/teto/rocks.nvim/lua/rocks/api/hooks.lua:72 | Running preload hooks DEBUG | 2025-03-13 19:04:09.368 | /home/teto/rocks.nvim/lua/rocks/adapter.lua:42 | Symlink directory lua exists already. TRACE | 2025-03-13 19:04:09.774 | /home/teto/rocks.nvim/lua/rocks/runtime.lua:72 | Sourcing start plugins ====