### PR TITLE
build: update luarocks version in install script

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -208,7 +208,7 @@ local function set_up_luarocks(install_path)
         return false
     end
 
-    local luarocks_version = "v3.11.1"
+    local luarocks_version = "v3.12.2"
     sc = exec({
         "git",
         "checkout",


### PR DESCRIPTION
I was running into [this issue](https://github.com/luarocks/luarocks/issues/1797) in luarocks while trying to install via the installer.lua script. Later in that issue they fixed it in 3.12.0. 

I used 3.12.2 to install on my machine (Fedora 42) and everything appears to be functioning. I know you are working on getting Lux working. But figured an intermediate fix would be nice.