### PR TITLE
fix: suppress neovim master warning

### DIFF
--- a/lua/rocks/log.lua
+++ b/lua/rocks/log.lua
@@ -102,7 +102,7 @@ function log.set_level(level)
         assert(log_levels[level], string.format("rocks.nvim: Invalid log level: %d", level))
         log.level = level
     end
-    vim.lsp.set_log_level(log.level)
+    vim.lsp.log.set_level(log.level)
 end
 
 for level, levelnr in pairs(vim.log.levels) do


### PR DESCRIPTION
Otherwise one gets:

```
vim.lsp.set_log_level() is deprecated. Run ":checkhealth vim.deprecated" for more information
```