### PR TITLE
tests: move setup instructions to setup()

### DIFF
--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -1,14 +1,17 @@
 vim.env.PLENARY_TEST_TIMEOUT = 60000
 
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     rocks_path = tempdir,
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
 }
 
 describe("config", function()
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     local config = require("rocks.config.internal")
     local constants = require("rocks.constants")
     it("default servers", function()

--- a/spec/hook_spec.lua
+++ b/spec/hook_spec.lua
@@ -1,7 +1,5 @@
 local tempdir = vim.fn.tempname()
 local rtp_dir = vim.fs.joinpath(tempdir, "rtp")
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
@@ -9,6 +7,10 @@ vim.g.rocks_nvim = {
 }
 
 describe("hooks", function()
+    setup(function()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     it("modifiers and actions", function()
         local config = require("rocks.config.internal")
         -- Test sync without any rocks

--- a/spec/operations/bulk_install_spec.lua
+++ b/spec/operations/bulk_install_spec.lua
@@ -1,6 +1,4 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
@@ -11,6 +9,9 @@ local fs = require("rocks.fs")
 local config = require("rocks.config.internal")
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
 describe("bulk install", function()
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+    end)
     nio.tests.it("synchronises rocks installations", function()
         local to_install = {
             { name = "neorg", version = "7.0.0" },

--- a/spec/operations/helpers_spec.lua
+++ b/spec/operations/helpers_spec.lua
@@ -1,6 +1,4 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
@@ -10,6 +8,10 @@ vim.g.rocks_nvim = {
 local nio = require("nio")
 vim.env.PLENARY_TEST_TIMEOUT = 60000
 describe("operations.helpers", function()
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
     local helpers = require("rocks.operations.helpers")
     local config = require("rocks.config.internal")
     local state = require("rocks.state")

--- a/spec/operations/install_update_spec.lua
+++ b/spec/operations/install_update_spec.lua
@@ -1,6 +1,4 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
@@ -11,6 +9,12 @@ vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
 describe("install/update", function()
     local operations = require("rocks.operations")
     local state = require("rocks.state")
+
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     nio.tests.it("install and update rocks", function()
         local autocmd_future = nio.control.future()
         vim.api.nvim_create_autocmd("User", {

--- a/spec/operations/pin_commands_spec.lua
+++ b/spec/operations/pin_commands_spec.lua
@@ -1,6 +1,4 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
@@ -20,6 +18,11 @@ end
 
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
 describe("Rocks pin/unpin", function()
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     nio.tests.it("pin/unpin plugin with only version", function()
         local rocks_toml = parse_config()
         rocks_toml.plugins = {}

--- a/spec/operations/pin_spec.lua
+++ b/spec/operations/pin_spec.lua
@@ -1,16 +1,20 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
 }
-local nio = require("nio")
 vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
 describe("install/pin/update", function()
+    local nio = require("nio")
     local operations = require("rocks.operations")
     local state = require("rocks.state")
+
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     nio.tests.it("update skips pinned install", function()
         local future = nio.control.future()
         operations.add({ "neorg", "7.0.0", "pin=true" }, {

--- a/spec/operations/sync_spec.lua
+++ b/spec/operations/sync_spec.lua
@@ -1,6 +1,4 @@
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
     rocks_path = tempdir,

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -1,8 +1,6 @@
 vim.env.PLENARY_TEST_TIMEOUT = 60000
 
 local tempdir = vim.fn.tempname()
-vim.system({ "rm", "-r", tempdir }):wait()
-vim.system({ "mkdir", "-p", tempdir }):wait()
 vim.g.rocks_nvim = {
     rocks_path = tempdir,
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
@@ -16,6 +14,12 @@ describe("plugin initialization", function()
 
     local cwd = vim.fn.getcwd()
     local plugin_script = vim.fs.joinpath(cwd, "plugin", "rocks.lua")
+
+    setup(function()
+        vim.system({ "rm", "-r", tempdir }):wait()
+        vim.system({ "mkdir", "-p", tempdir }):wait()
+    end)
+
     vim.cmd.source(plugin_script)
     it("emits no notifications", function()
         assert.True(vim.g.loaded_rocks_nvim)


### PR DESCRIPTION
trying to run busted with a filter would trigger:

```
➜ busted --tags=offline spec 
✱
0 successes / 0 failures / 1 error / 0 pending : 0.109413 seconds

Error → spec/operations/install_update_spec.lua @ 9
install/update
lua/rocks/operations/helpers/init.lua:18: loop or previous error loading module 'rocks.luarocks'

stack traceback:
	lua/rocks/operations/helpers/init.lua:18: in main chunk

E5113: Error while calling lua chunk: [NULL]
Error executing callback:
...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
lua/rocks/config/internal.lua:36: E5560: Vimscript function must not be called in a fast event context
stack traceback:
	[C]: in function 'require'
	lua/rocks/adapter.lua:164: in function 'init_site_symlinks_async'
	lua/rocks/adapter.lua:207: in function 'synchronise_site_symlinks'
	lua/rocks/adapter.lua:199: in function 'ensure_site_links'
	lua/rocks/adapter.lua:213: in function 'func'
	...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:169: in function <...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:168>
stack traceback:
	[C]: in function 'error'
	...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:100: in function 'close_task'
	...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:122: in function 'cb'
	...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:183: in function <...wsk-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:182>
	[C]: in function 'wait'
	...-unwrapped-0.11.4/share/nvim/runtime/lua/vim/_system.lua:90: in function 'wait'
	spec/operations/install_update_spec.lua:10: in function <spec/operations/install_update_spec.lua:9>
	[C]: in function 'xpcall'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:178: in function 'safe'
	...s8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/block.lua:146: in function 'execute'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/init.lua:15: in function 'executor'
	...
	...s8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/block.lua:155: in function 'execute'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/init.lua:7: in function 'executor'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314: in function <...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314>
	[C]: in function 'xpcall'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:178: in function 'safe'
	...ss8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/core.lua:314: in function 'execute'
	...k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/execute.lua:58: in function 'execute'
	...8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/runner.lua:210: in function <...8k-lua5.1-busted-2.2.0-1/share/lua/5.1/busted/runner.lua:11>
	...d-2.2.0-1/busted-2.2.0-1-rocks/busted/2.2.0-1/bin/busted:3: in function 'fn'
	...pmjlpxbip0nidvnawva4wibj6a9-lua5.1-nlua-0.3.1-1/bin/nlua:89: in main chunk
```

This seems to be because busted tries to read the "blocks" (see busted/block.lua) and having the `vim.system({ "rm", "-r", tempdir }):wait()` messes up with that code.

So I moved those to a setup() inside the global describe in each file. This seems to do the trick.