### PR TITLE
ci: update windows image

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - host: ubuntu-24.04
-          - host: windows-2019
+          - host: windows-2022
           - host: macos-13 # x86_64
           - host: macos-14 # aarch64
     steps:


### PR DESCRIPTION
the windows-2019 image disappeared from GH actions. Bump the image. https://github.com/actions/runner-images/issues/12045