### PR TITLE
fix(nix): make sure tests can run in checkPhase

### DIFF
--- a/.busted
+++ b/.busted
@@ -8,7 +8,8 @@ return {
         verbose = true,
     },
     offline = {
-        exclude_tags = {"online"},
+        ["exclude-tags"] = {"online"},
+        ["keep-going"] = false,
         verbose = true,
     },
     tests = {

--- a/lua/rocks/adapter.lua
+++ b/lua/rocks/adapter.lua
@@ -161,6 +161,7 @@ end
 --- so that colorschemes are available before rocks.nvim
 --- has initialised.
 local function init_site_symlinks_async()
+    nio.scheduler() -- In tests, this can lead to a vimscript function being invoked by nvim-nio
     local state = require("rocks.state")
     vim
         .iter(state.installed_rocks())

--- a/spec/adapter_spec.lua
+++ b/spec/adapter_spec.lua
@@ -4,8 +4,8 @@ vim.g.rocks_nvim = {
     rocks_path = tempdir,
 }
 
+vim.env.PLENARY_TEST_TIMEOUT = 1000 * 60
 local nio = require("nio")
-vim.env.PLENARY_TEST_TIMEOUT = 60000
 local adapter = require("rocks.adapter")
 local config = require("rocks.config.internal")
 local operations = require("rocks.operations")
@@ -24,7 +24,7 @@ describe("rocks.adapter", function()
         adapter.init()
     end)
 
-    nio.tests.it("Can run checkhealth for luarocks plugins", function()
+    nio.tests.it("Can run checkhealth for luarocks plugins #online", function()
         local mock_health = mock({
             check = function(_) end,
         })

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -1,5 +1,3 @@
-vim.env.PLENARY_TEST_TIMEOUT = 60000
-
 local tempdir = vim.fn.tempname()
 vim.g.rocks_nvim = {
     rocks_path = tempdir,

--- a/spec/loader_spec.lua
+++ b/spec/loader_spec.lua
@@ -1,4 +1,3 @@
-vim.env.PLENARY_TEST_TIMEOUT = 60000
 vim.g.rocks_nvim = {
     luarocks_binary = "luarocks",
 }

--- a/spec/luarocks_config_spec.lua
+++ b/spec/luarocks_config_spec.lua
@@ -1,7 +1,5 @@
 local nio = require("nio")
 
-vim.env.PLENARY_TEST_TIMEOUT = 60000
-
 describe("luarocks config", function()
     nio.tests.it("extra luarocks_config", function()
         local tempdir = vim.fn.tempname()

--- a/spec/operations/bulk_install_spec.lua
+++ b/spec/operations/bulk_install_spec.lua
@@ -7,8 +7,8 @@ vim.g.rocks_nvim = {
 local nio = require("nio")
 local fs = require("rocks.fs")
 local config = require("rocks.config.internal")
-vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("bulk install", function()
+vim.env.PLENARY_TEST_TIMEOUT = 1000 * 60
+describe("bulk install #online", function()
     setup(function()
         vim.system({ "rm", "-r", tempdir }):wait()
     end)

--- a/spec/operations/helpers_spec.lua
+++ b/spec/operations/helpers_spec.lua
@@ -6,7 +6,7 @@ vim.g.rocks_nvim = {
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
 }
 local nio = require("nio")
-vim.env.PLENARY_TEST_TIMEOUT = 60000
+vim.env.PLENARY_TEST_TIMEOUT = 1000 * 60
 describe("operations.helpers", function()
     setup(function()
         vim.system({ "rm", "-r", tempdir }):wait()
@@ -16,7 +16,7 @@ describe("operations.helpers", function()
     local config = require("rocks.config.internal")
     local state = require("rocks.state")
     vim.system({ "mkdir", "-p", config.rocks_path }):wait()
-    nio.tests.it("install/remove", function()
+    nio.tests.it("install/remove #online", function()
         helpers.install({ name = "plenary.nvim" }).wait()
         ---@diagnostic disable-next-line: missing-fields
         local result = vim.fs.find("plenary", { path = config.rocks_path, type = "directory" })
@@ -54,7 +54,7 @@ describe("operations.helpers", function()
         assert.is_nil(result.baz)
         assert.same("foo 7.0.0 -> 8.0.0", tostring(result.foo))
     end)
-    nio.tests.it("Install rock stub", function()
+    nio.tests.it("Install rock stub #online", function()
         local installed_rocks = state.installed_rocks()
         assert.is_nil(installed_rocks["stub.nvim"])
         helpers.manage_rock_stub({

--- a/spec/operations/pin_commands_spec.lua
+++ b/spec/operations/pin_commands_spec.lua
@@ -16,8 +16,8 @@ local function parse_config()
     return require("toml_edit").parse(config_file_content)
 end
 
-vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("Rocks pin/unpin #online", function()
+vim.env.PLENARY_TEST_TIMEOUT = 6000
+describe("Rocks pin/unpin", function()
     setup(function()
         vim.system({ "rm", "-r", tempdir }):wait()
         vim.system({ "mkdir", "-p", tempdir }):wait()

--- a/spec/operations/pin_spec.lua
+++ b/spec/operations/pin_spec.lua
@@ -4,7 +4,7 @@ vim.g.rocks_nvim = {
     rocks_path = tempdir,
     config_path = vim.fs.joinpath(tempdir, "rocks.toml"),
 }
-vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
+vim.env.PLENARY_TEST_TIMEOUT = 1000 * 60
 describe("install/pin/update #online", function()
     local nio = require("nio")
     local operations = require("rocks.operations")

--- a/spec/operations/sync_spec.lua
+++ b/spec/operations/sync_spec.lua
@@ -9,10 +9,10 @@ local operations = require("rocks.operations")
 local helpers = require("rocks.operations.helpers")
 local state = require("rocks.state")
 local config = require("rocks.config.internal")
-vim.env.PLENARY_TEST_TIMEOUT = 60000 * 5
-describe("#online operations", function()
+vim.env.PLENARY_TEST_TIMEOUT = 1000 * 60
+describe("operations", function()
     vim.system({ "mkdir", "-p", config.rocks_path }):wait()
-    nio.tests.it("sync", function()
+    nio.tests.it("sync #online", function()
         -- Test sync without any rocks
         local config_content = [[
 [rocks]

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -1,5 +1,3 @@
-vim.env.PLENARY_TEST_TIMEOUT = 60000
-
 local tempdir = vim.fn.tempname()
 vim.g.rocks_nvim = {
     rocks_path = tempdir,


### PR DESCRIPTION
Prefixing this with `fix:` so we get a new release that we can use to run tests in nixpkgs.

See:

- https://github.com/NixOS/nixpkgs/pull/381036.

This enables the `checkPhase` in the flake's rocks-nvim build, so we can catch impure tests not tagged as `#online` here in the future.